### PR TITLE
change to reasonable default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=chaintool
 LEIN = $(shell which lein || echo ./lein)
-BINDIR ?= /usr/bin
+BINDIR ?= /usr/local/bin
 OUTPUT=target/$(NAME)
 META=org.hyperledger.chaintool.meta
 


### PR DESCRIPTION
change to reasonable default `/usr/local/bin` for install location
rather than `usr/bin` which requires root (typically) privs.

tested with `make clean` followed by `make install` and checked that chaintool was in my path.

Signed-off-by: Christopher Ferris <chrisfer@us.ibm.com>