### PR TITLE
v1.0 release and v1.1-SNAPSHOT prep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "1.0"
+(defproject chaintool "1.1-SNAPSHOT"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "0.8-SNAPSHOT"
+(defproject chaintool "1.0"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"


### PR DESCRIPTION
This PR creates a v1.0 release and adjusts master to continue on with v1.1-SNAPSHOT.   After merge, I will create a tag/release on the 3fb6ded commit