### PR TITLE
V0.8.0 proposal

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "0.8.0"
+(defproject chaintool "0.8.1-SNAPSHOT"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "0.8-SNAPSHOT"
+(defproject chaintool "0.8.0"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"


### PR DESCRIPTION
This patch series creates a new v0.8.0 release at commit 	fb1755a, and also sets the branch state to prepare for v0.8.1 development.  If accepted, I will create a new v0.8.0 tag at fb1755a and push a binary distro, similar to how v0.7 was handled.

Changes since v0.7
-----------------
447fb66 Prepare for v0.8.1 development
fb1755a Release v0.8.0
408ea8d Add example for parameterless CCI functions
8ab87d0 Merge pull request #16 from ghaskins/fix-issue-13-v2
6ddb5d1 Allow parameterless functions
8916509 Merge pull request #14 from christo4ferris/fix-default-loc
5697879 change to reasonable default
a9ddd9e Create MAINTAINERS.txt
c7b4c87 Issue #8 - Warn if leiningen is not V2 or greater
063bc3e Update README.md
06e0efe Update README.md to incorporate Hyperledger acceptance
2b5f36a Merge remote-tracking branch 'upstream/master'
ff1c158 Create README.md
d657f26 Initial commit
453ef78 Merge pull request #7 from bren3582/patch-3
e48a86b Updated Makefile lein path, one directory deeper
9d5caab Fix make-clean target
b4648f3 Use a better name for test data
52a9597 Flag compilation error if enumerations do not contain a proper default value
072cfd1 Unify error-exit paths
26bf884 Cleanup based on lein-kibit report
aa63c1c Remove superfluous (and) form, leftover from porting rest client
cdad20f Add an SDK based example client to example02
0c38f6e Merge pull request #3 from bren3582/patch-2
1b8b7a2 Fixed a typo in my README update
aa0e4cb Merge pull request #2 from bren3582/patch-1
471f66b Notes for development mode and a few small updates
cca470d Update README.md
e0ebd6e Update REST clients to use new default port = 5000
b688ffc Add support for enums

Signed-off-by: Greg Haskins <gregory.haskins@gmail.com>
