### PR TITLE
Release v0.8.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "0.8.1"
+(defproject chaintool "0.8.2-SNAPSHOT"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "0.8.1-SNAPSHOT"
+(defproject chaintool "0.8.1"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"


### PR DESCRIPTION
Primary interest is pulling in bugfix #22 from commit bfd0a93

Changes since v0.8.0
-------
dc77af4 Prepare for v0.8.2 development
45450c0 Release v0.8.1
a150fee Merge pull request #23 from ghaskins/issue22-fix
b4bb0cd Merge pull request #20 from ghaskins/v0.8.0-proposal
bfd0a93 Allow zero length args in the golang stub to accommodate parameterless functions
cd2c99b Merge pull request #19 from christo4ferris/fix-default-loc
447fb66 Prepare for v0.8.1 development
5cf118a add build artifacts to .gitignore
5c78194 Merge pull request #17 from ghaskins/parameterless-example