### PR TITLE
Use ChaincodeStubInterface

### DIFF
--- a/documentation/platforms/golang/README.md
+++ b/documentation/platforms/golang/README.md
@@ -73,9 +73,9 @@ queries {
 ```
 requires a function signature that looks like:
 ```
-func (t *ChaincodeExample) CheckBalance(stub *shim.ChaincodeStub, param *example02.Entity) (*example02.BalanceResult, error) {}
+func (t *ChaincodeExample) CheckBalance(stub shim.ChaincodeStubInterface, param *example02.Entity) (*example02.BalanceResult, error) {}
 ```
-Every callback requires a shim.ChaincodeStub pointer as its first parameter, followed by an input parameter and return parameter as declared in the interface definition.  Functions that return _void_ simply return a single _error_ rather than _(type, error)_.
+Every callback requires a shim.ChaincodeStubInterface as its first parameter, followed by an input parameter and return parameter as declared in the interface definition.  Functions that return _void_ simply return a single _error_ rather than _(type, error)_.
 ## Generated Code File Structure
 ### Overview
 All generated code is placed in directories rooted at $PROJECT_ROOT/build which, as mentioned earlier, is implicitly included in the $GOPATH. Interfaces are emitted to $PROJECT_ROOT/build/src/hyperledger/cci/..., and general chaincode support stubs are emitted to $PROJECT_ROOT/build/src/hyperledger/ccs.

--- a/examples/example02/app/src/chaincode/chaincode_example02.go
+++ b/examples/example02/app/src/chaincode/chaincode_example02.go
@@ -36,7 +36,7 @@ type ChaincodeExample struct {
 }
 
 // Called to initialize the chaincode
-func (t *ChaincodeExample) Init(stub *shim.ChaincodeStub, param *appinit.Init) error {
+func (t *ChaincodeExample) Init(stub shim.ChaincodeStubInterface, param *appinit.Init) error {
 
 	var err error
 
@@ -57,7 +57,7 @@ func (t *ChaincodeExample) Init(stub *shim.ChaincodeStub, param *appinit.Init) e
 }
 
 // Transaction makes payment of X units from A to B
-func (t *ChaincodeExample) MakePayment(stub *shim.ChaincodeStub, param *example02.PaymentParams) error {
+func (t *ChaincodeExample) MakePayment(stub shim.ChaincodeStubInterface, param *example02.PaymentParams) error {
 
 	var err error
 
@@ -93,7 +93,7 @@ func (t *ChaincodeExample) MakePayment(stub *shim.ChaincodeStub, param *example0
 }
 
 // Deletes an entity from state
-func (t *ChaincodeExample) DeleteAccount(stub *shim.ChaincodeStub, param *example02.Entity) error {
+func (t *ChaincodeExample) DeleteAccount(stub shim.ChaincodeStubInterface, param *example02.Entity) error {
 
 	// Delete the key from the state in ledger
 	err := stub.DelState(param.Id)
@@ -105,7 +105,7 @@ func (t *ChaincodeExample) DeleteAccount(stub *shim.ChaincodeStub, param *exampl
 }
 
 // Query callback representing the query of a chaincode
-func (t *ChaincodeExample) CheckBalance(stub *shim.ChaincodeStub, param *example02.Entity) (*example02.BalanceResult, error) {
+func (t *ChaincodeExample) CheckBalance(stub shim.ChaincodeStubInterface, param *example02.Entity) (*example02.BalanceResult, error) {
 	var err error
 
 	// Get the state from the ledger
@@ -134,11 +134,11 @@ func main() {
 //-------------------------------------------------
 // Helpers
 //-------------------------------------------------
-func (t *ChaincodeExample) PutState(stub *shim.ChaincodeStub, party *appinit.Party) error {
+func (t *ChaincodeExample) PutState(stub shim.ChaincodeStubInterface, party *appinit.Party) error {
 	return stub.PutState(party.Entity, []byte(strconv.Itoa(int(party.Value))))
 }
 
-func (t *ChaincodeExample) GetState(stub *shim.ChaincodeStub, entity string) (int, error) {
+func (t *ChaincodeExample) GetState(stub shim.ChaincodeStubInterface, entity string) (int, error) {
 	bytes, err := stub.GetState(entity)
 	if err != nil {
 		return 0, errors.New("Failed to get state")

--- a/examples/invoker/src/chaincode/chaincode.go
+++ b/examples/invoker/src/chaincode/chaincode.go
@@ -33,7 +33,7 @@ type ChaincodeExample struct {
 }
 
 // Called to initialize the chaincode
-func (t *ChaincodeExample) Init(stub *shim.ChaincodeStub, param *appinit.Init) error {
+func (t *ChaincodeExample) Init(stub shim.ChaincodeStubInterface, param *appinit.Init) error {
 
 	var err error
 
@@ -47,7 +47,7 @@ func (t *ChaincodeExample) Init(stub *shim.ChaincodeStub, param *appinit.Init) e
 }
 
 // Transaction makes payment of X units from A to B
-func (t *ChaincodeExample) MakePayment(stub *shim.ChaincodeStub, param *example02.PaymentParams) error {
+func (t *ChaincodeExample) MakePayment(stub shim.ChaincodeStubInterface, param *example02.PaymentParams) error {
 
 	var err error
 
@@ -61,7 +61,7 @@ func (t *ChaincodeExample) MakePayment(stub *shim.ChaincodeStub, param *example0
 }
 
 // Deletes an entity from state
-func (t *ChaincodeExample) DeleteAccount(stub *shim.ChaincodeStub, param *example02.Entity) error {
+func (t *ChaincodeExample) DeleteAccount(stub shim.ChaincodeStubInterface, param *example02.Entity) error {
 
 	var err error
 
@@ -75,7 +75,7 @@ func (t *ChaincodeExample) DeleteAccount(stub *shim.ChaincodeStub, param *exampl
 }
 
 // Query callback representing the query of a chaincode
-func (t *ChaincodeExample) CheckBalance(stub *shim.ChaincodeStub, param *example02.Entity) (*example02.BalanceResult, error) {
+func (t *ChaincodeExample) CheckBalance(stub shim.ChaincodeStubInterface, param *example02.Entity) (*example02.BalanceResult, error) {
 
 	var err error
 

--- a/examples/parameterless/src/chaincode/main.go
+++ b/examples/parameterless/src/chaincode/main.go
@@ -33,12 +33,12 @@ type ChaincodeExample struct {
 }
 
 // Called to initialize the chaincode
-func (t *ChaincodeExample) Init(stub *shim.ChaincodeStub, param *appinit.Init) error {
+func (t *ChaincodeExample) Init(stub shim.ChaincodeStubInterface, param *appinit.Init) error {
 
 	return nil
 }
 
-func (t *ChaincodeExample) TestParameterless(stub *shim.ChaincodeStub) (*app.MyReturnType, error) {
+func (t *ChaincodeExample) TestParameterless(stub shim.ChaincodeStubInterface) (*app.MyReturnType, error) {
 	return nil, nil
 }
 

--- a/examples/sample_syscc/sample_syscc.go
+++ b/examples/sample_syscc/sample_syscc.go
@@ -28,7 +28,7 @@ import (
 type SampleSysCC struct {
 }
 
-func (t *SampleSysCC) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+func (t *SampleSysCC) Init(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 	var key, val string    // Entities
 
 	if len(args) != 2 {
@@ -48,7 +48,7 @@ func (t *SampleSysCC) Init(stub *shim.ChaincodeStub, function string, args []str
 }
 
 // Transaction makes payment of X units from A to B
-func (t *SampleSysCC) Invoke(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+func (t *SampleSysCC) Invoke(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 	var key, val string    // Entities
 
 	if len(args) != 2 {
@@ -75,7 +75,7 @@ func (t *SampleSysCC) Invoke(stub *shim.ChaincodeStub, function string, args []s
 }
 
 // Query callback representing the query of a chaincode
-func (t *SampleSysCC) Query(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+func (t *SampleSysCC) Query(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 	if function != "getval" {
 		return nil, errors.New("Invalid query function name. Expecting \"getval\"")
 	}

--- a/resources/generators/golang.stg
+++ b/resources/generators/golang.stg
@@ -35,7 +35,7 @@ var txnre   = regexp.MustCompile("([a-zA-Z0-9.]*)/txn/([0-9]*)")
 var queryre = regexp.MustCompile("([a-zA-Z0-9.]*)/query/([0-9]*)")
 
 // Initialization function, called only once
-func (self *stubHandler) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+func (self *stubHandler) Init(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 
 	if len(args) != 1 {
 		return nil, errors.New("Expected exactly one argument")
@@ -146,8 +146,8 @@ import (
 )
 
 type Dispatcher interface {
-     DispatchTxn(stub *shim.ChaincodeStub, function int, params string) ([]byte, error)
-     DispatchQuery(stub *shim.ChaincodeStub, function int, params string) ([]byte, error)
+     DispatchTxn(stub shim.ChaincodeStubInterface, function int, params string) ([]byte, error)
+     DispatchQuery(stub shim.ChaincodeStubInterface, function int, params string) ([]byte, error)
 }
 
 type Factory interface {
@@ -206,7 +206,7 @@ var facts = &meta.Facts {
 type ChaincodeMetaData struct {
 }
 
-func (self *ChaincodeMetaData) GetInterfaces(stub *shim.ChaincodeStub, params *meta.GetInterfacesParams) (*meta.Interfaces, error) {
+func (self *ChaincodeMetaData) GetInterfaces(stub shim.ChaincodeStubInterface, params *meta.GetInterfacesParams) (*meta.Interfaces, error) {
 
 	response := &meta.Interfaces{}
 	for name, data := range interfaces {
@@ -222,7 +222,7 @@ func (self *ChaincodeMetaData) GetInterfaces(stub *shim.ChaincodeStub, params *m
 	return response, nil
 }
 
-func (self *ChaincodeMetaData) GetInterface(stub *shim.ChaincodeStub, params *meta.GetInterfaceParams) (*meta.InterfaceDescriptor, error) {
+func (self *ChaincodeMetaData) GetInterface(stub shim.ChaincodeStubInterface, params *meta.GetInterfaceParams) (*meta.InterfaceDescriptor, error) {
 
 	intf, ok := interfaces[params.Name]
 	if !ok {
@@ -232,7 +232,7 @@ func (self *ChaincodeMetaData) GetInterface(stub *shim.ChaincodeStub, params *me
 	return &meta.InterfaceDescriptor{Data: intf}, nil
 }
 
-func (self *ChaincodeMetaData) GetFacts(stub *shim.ChaincodeStub, params *meta.GetFactsParams) (*meta.Facts, error) {
+func (self *ChaincodeMetaData) GetFacts(stub shim.ChaincodeStubInterface, params *meta.GetFactsParams) (*meta.Facts, error) {
 
 	return facts, nil
 }
@@ -284,7 +284,7 @@ func (self *factoryImpl) Create(intf interface{}) (api.Dispatcher, error) {
      return &stubImpl{intf: intf.(CCInterface)}, nil
 }
 
-func (self *stubImpl) DispatchTxn(stub *shim.ChaincodeStub, function int, params string) ([]byte, error) {
+func (self *stubImpl) DispatchTxn(stub shim.ChaincodeStubInterface, function int, params string) ([]byte, error) {
         // Handle different functions
         switch {
         <dispatchfunctions(true, intf, intf.transactions)>
@@ -293,7 +293,7 @@ func (self *stubImpl) DispatchTxn(stub *shim.ChaincodeStub, function int, params
         }
 }
 
-func (self *stubImpl) DispatchQuery(stub *shim.ChaincodeStub, function int, params string) ([]byte, error) {
+func (self *stubImpl) DispatchQuery(stub shim.ChaincodeStubInterface, function int, params string) ([]byte, error) {
         // Handle different functions
         switch {
         <dispatchfunctions(true, intf, intf.queries)>
@@ -352,7 +352,7 @@ dispatchfunctions(txn, intf, functions) ::= "<functions.values:{x | <dispatchfun
 
 declarefunctions(intf, functions) ::=
 <<
-<functions.values:{x | <x.name>(*shim.ChaincodeStub<if(x.param)>, *<x.param><endif>) <if(x.rettype)>(*<x.rettype>, error)<else>error<endif> }; separator="\n">
+<functions.values:{x | <x.name>(shim.ChaincodeStubInterface<if(x.param)>, *<x.param><endif>) <if(x.rettype)>(*<x.rettype>, error)<else>error<endif> }; separator="\n">
 >>
 
 dispatchfunction(txn, intf, func) ::=
@@ -363,7 +363,7 @@ case function == <func.index>:
 
 implementhandler(txn) ::=
 <<
-func (self *stubHandler) <if(txn)>Invoke<else>Query<endif>(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+func (self *stubHandler) <if(txn)>Invoke<else>Query<endif>(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 
         var params string;
 
@@ -383,7 +383,7 @@ func (self *stubHandler) <if(txn)>Invoke<else>Query<endif>(stub *shim.ChaincodeS
 implementserver(intf, func) ::=
 <<
 
-func (self *stubImpl) proxy<func.name>(stub *shim.ChaincodeStub, _params string) ([]byte, error) {
+func (self *stubImpl) proxy<func.name>(stub shim.ChaincodeStubInterface, _params string) ([]byte, error) {
 
      var err error;
 
@@ -421,7 +421,7 @@ func (self *stubImpl) proxy<func.name>(stub *shim.ChaincodeStub, _params string)
 implementclient(txn, intf, func) ::=
 <<
 
-func <func.name>(stub *shim.ChaincodeStub, chaincodeName string<if(func.param)>, params *<func.param><endif>) <\\>
+func <func.name>(stub shim.ChaincodeStubInterface, chaincodeName string<if(func.param)>, params *<func.param><endif>) <\\>
 <if(func.rettype)>(*<func.rettype>, error)<else>error<endif> {
 
      args := make([]string, 1)


### PR DESCRIPTION
For whenever the changes get made to hyperledger/fabric to stop using *shim.ChaincodeStub and use an interface instead.

Signed-off-by: Bradley Gorman <bgorman@au1.ibm.com>