### PR TITLE
Explicitly set -server in the JVM options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "0.9.1"
+(defproject chaintool "0.9.2-SNAPSHOT"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chaintool "0.9.1-SNAPSHOT"
+(defproject chaintool "0.9.1"
   :description "hyperledger chaincode tool"
   :url "https://github.com/ghaskins/chaintool"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :min-lein-version "2.0.0"
   :lein-release {:deploy-via :shell :shell ["true"]}
   :javac-options ["-target" "1.7" "-source" "1.7"]
+  :jvm-opts ["-server"]
   :java-source-paths ["src"]
   :plugins [[lein-bin "0.3.5"]]
   :dependencies [[org.clojure/clojure "1.8.0"]


### PR DESCRIPTION
It was discovered that chaintool would not run on Power
systems because the JVM would complain about the -client
switch being passed in.  This switch was emitted into
the JAR preamble script created by the lein-bin plugin.

It seems that the -client/-server option is a no-op on
modern 64 bit JVMs.  For some reason, the OpenJDK-8
on Power seems to reject any setting of -client whereas
this works fine on x86 and Z (even for the same exact
version of OpenJDK-8).  Therefore, we set the :jvm-opts
flag for the project which modifies how the lein-bin
plugin emits code to work around the issue.  If the
rumors regarding the efficacy of the switch are true,
this should have zero negative impact on Z/X86 while
allowing P to work around the problem.

Fixes Issue #28

Signed-off-by: Gregory Haskins <gregory.haskins@gmail.com>