### PR TITLE
Upgrade protobuf and java compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: clojure
+jdk:
+  - oraclejdk8

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [org.antlr/ST4 "4.0.8"]
                  [me.raynes/conch "0.8.0"]
                  [me.raynes/fs "1.4.6"]
-                 [org.clojars.ghaskins/protobuf "0.2"]
+                 [org.clojars.ghaskins/protobuf "3.0.2-1"]
                  [commons-io/commons-io "2.5"]
                  [org.tukaani/xz "1.5"]
                  [org.apache.commons/commons-compress "1.11"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0.txt"}
   :min-lein-version "2.0.0"
   :lein-release {:deploy-via :shell :shell ["true"]}
-  :javac-options ["-target" "1.7" "-source" "1.7"]
+  :javac-options ["-target" "1.8" "-source" "1.8"]
   :jvm-opts ["-server"]
   :java-source-paths ["src"]
   :plugins [[lein-bin "0.3.5"]]
@@ -18,7 +18,7 @@
                  [org.antlr/ST4 "4.0.8"]
                  [me.raynes/conch "0.8.0"]
                  [me.raynes/fs "1.4.6"]
-                 [org.clojars.ghaskins/protobuf "3.0.2-1"]
+                 [org.clojars.ghaskins/protobuf "3.0.2-2"]
                  [commons-io/commons-io "2.5"]
                  [org.tukaani/xz "1.5"]
                  [org.apache.commons/commons-compress "1.11"]

--- a/src/chaintool/car/abi/Car.java
+++ b/src/chaintool/car/abi/Car.java
@@ -6,7 +6,13 @@ package chaintool.car.abi;
 public final class Car {
   private Car() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface CompatibilityHeaderOrBuilder extends
       // @@protoc_insertion_point(interface_extends:chaintool.car.abi.CompatibilityHeader)
@@ -38,7 +44,7 @@ public final class Car {
     /**
      * <code>repeated string features = 3;</code>
      */
-    com.google.protobuf.ProtocolStringList
+    java.util.List<java.lang.String>
         getFeaturesList();
     /**
      * <code>repeated string features = 3;</code>
@@ -58,11 +64,11 @@ public final class Car {
    * Protobuf type {@code chaintool.car.abi.CompatibilityHeader}
    */
   public  static final class CompatibilityHeader extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:chaintool.car.abi.CompatibilityHeader)
       CompatibilityHeaderOrBuilder {
     // Use CompatibilityHeader.newBuilder() to construct.
-    private CompatibilityHeader(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private CompatibilityHeader(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private CompatibilityHeader() {
@@ -78,7 +84,8 @@ public final class Car {
     }
     private CompatibilityHeader(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -121,11 +128,10 @@ public final class Car {
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
           features_ = features_.getUnmodifiableView();
@@ -139,7 +145,7 @@ public final class Car {
       return chaintool.car.abi.Car.internal_static_chaintool_car_abi_CompatibilityHeader_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return chaintool.car.abi.Car.internal_static_chaintool_car_abi_CompatibilityHeader_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -254,13 +260,13 @@ public final class Car {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, magic_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, magic_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeInt32(2, version_);
       }
       for (int i = 0; i < features_.size(); i++) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 3, features_.getRaw(i));
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, features_.getRaw(i));
       }
       unknownFields.writeTo(output);
     }
@@ -271,7 +277,7 @@ public final class Car {
 
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, magic_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, magic_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -291,6 +297,57 @@ public final class Car {
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof chaintool.car.abi.Car.CompatibilityHeader)) {
+        return super.equals(obj);
+      }
+      chaintool.car.abi.Car.CompatibilityHeader other = (chaintool.car.abi.Car.CompatibilityHeader) obj;
+
+      boolean result = true;
+      result = result && (hasMagic() == other.hasMagic());
+      if (hasMagic()) {
+        result = result && getMagic()
+            .equals(other.getMagic());
+      }
+      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion()) {
+        result = result && (getVersion()
+            == other.getVersion());
+      }
+      result = result && getFeaturesList()
+          .equals(other.getFeaturesList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (hasMagic()) {
+        hash = (37 * hash) + MAGIC_FIELD_NUMBER;
+        hash = (53 * hash) + getMagic().hashCode();
+      }
+      if (hasVersion()) {
+        hash = (37 * hash) + VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + getVersion();
+      }
+      if (getFeaturesCount() > 0) {
+        hash = (37 * hash) + FEATURES_FIELD_NUMBER;
+        hash = (53 * hash) + getFeaturesList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static chaintool.car.abi.Car.CompatibilityHeader parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -314,34 +371,40 @@ public final class Car {
     }
     public static chaintool.car.abi.Car.CompatibilityHeader parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static chaintool.car.abi.Car.CompatibilityHeader parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static chaintool.car.abi.Car.CompatibilityHeader parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static chaintool.car.abi.Car.CompatibilityHeader parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static chaintool.car.abi.Car.CompatibilityHeader parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static chaintool.car.abi.Car.CompatibilityHeader parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -358,7 +421,7 @@ public final class Car {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -366,7 +429,7 @@ public final class Car {
      * Protobuf type {@code chaintool.car.abi.CompatibilityHeader}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:chaintool.car.abi.CompatibilityHeader)
         chaintool.car.abi.Car.CompatibilityHeaderOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -374,7 +437,7 @@ public final class Car {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_CompatibilityHeader_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_CompatibilityHeader_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -387,12 +450,13 @@ public final class Car {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -445,6 +509,32 @@ public final class Car {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof chaintool.car.abi.Car.CompatibilityHeader) {
           return mergeFrom((chaintool.car.abi.Car.CompatibilityHeader)other);
@@ -498,7 +588,7 @@ public final class Car {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (chaintool.car.abi.Car.CompatibilityHeader) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -708,6 +798,16 @@ public final class Car {
         onChanged();
         return this;
       }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:chaintool.car.abi.CompatibilityHeader)
     }
@@ -728,16 +828,7 @@ public final class Car {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new CompatibilityHeader(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -786,11 +877,11 @@ public final class Car {
    * Protobuf type {@code chaintool.car.abi.Archive}
    */
   public  static final class Archive extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:chaintool.car.abi.Archive)
       ArchiveOrBuilder {
     // Use Archive.newBuilder() to construct.
-    private Archive(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Archive(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Archive() {
@@ -804,7 +895,8 @@ public final class Car {
     }
     private Archive(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -829,7 +921,7 @@ public final class Car {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = signature_.toBuilder();
               }
-              signature_ = input.readMessage(chaintool.car.abi.Car.Archive.Signature.parser(), extensionRegistry);
+              signature_ = input.readMessage(chaintool.car.abi.Car.Archive.Signature.PARSER, extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(signature_);
                 signature_ = subBuilder.buildPartial();
@@ -845,11 +937,10 @@ public final class Car {
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -860,7 +951,7 @@ public final class Car {
       return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -907,11 +998,11 @@ public final class Car {
      * Protobuf type {@code chaintool.car.abi.Archive.Signature}
      */
     public  static final class Signature extends
-        com.google.protobuf.GeneratedMessage implements
+        com.google.protobuf.GeneratedMessageV3 implements
         // @@protoc_insertion_point(message_implements:chaintool.car.abi.Archive.Signature)
         SignatureOrBuilder {
       // Use Signature.newBuilder() to construct.
-      private Signature(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      private Signature(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
       }
       private Signature() {
@@ -927,7 +1018,8 @@ public final class Car {
       }
       private Signature(
           com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
         this();
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -972,11 +1064,10 @@ public final class Car {
             }
           }
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw new RuntimeException(e.setUnfinishedMessage(this));
+          throw e.setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
-          throw new RuntimeException(
-              new com.google.protobuf.InvalidProtocolBufferException(
-                  e.getMessage()).setUnfinishedMessage(this));
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
         } finally {
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
@@ -987,7 +1078,7 @@ public final class Car {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Signature_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Signature_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1002,11 +1093,11 @@ public final class Car {
         /**
          * <code>NONE = 1;</code>
          */
-        NONE(0, 1),
+        NONE(1),
         /**
          * <code>RSA = 2;</code>
          */
-        RSA(1, 2),
+        RSA(2),
         ;
 
         /**
@@ -1023,7 +1114,15 @@ public final class Car {
           return value;
         }
 
+        /**
+         * @deprecated Use {@link #forNumber(int)} instead.
+         */
+        @java.lang.Deprecated
         public static Type valueOf(int value) {
+          return forNumber(value);
+        }
+
+        public static Type forNumber(int value) {
           switch (value) {
             case 1: return NONE;
             case 2: return RSA;
@@ -1039,13 +1138,13 @@ public final class Car {
             Type> internalValueMap =
               new com.google.protobuf.Internal.EnumLiteMap<Type>() {
                 public Type findValueByNumber(int number) {
-                  return Type.valueOf(number);
+                  return Type.forNumber(number);
                 }
               };
 
         public final com.google.protobuf.Descriptors.EnumValueDescriptor
             getValueDescriptor() {
-          return getDescriptor().getValues().get(index);
+          return getDescriptor().getValues().get(ordinal());
         }
         public final com.google.protobuf.Descriptors.EnumDescriptor
             getDescriptorForType() {
@@ -1067,11 +1166,9 @@ public final class Car {
           return VALUES[desc.getIndex()];
         }
 
-        private final int index;
         private final int value;
 
-        private Type(int index, int value) {
-          this.index = index;
+        private Type(int value) {
           this.value = value;
         }
 
@@ -1168,7 +1265,7 @@ public final class Car {
           output.writeEnum(1, type_);
         }
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          com.google.protobuf.GeneratedMessage.writeString(output, 2, description_);
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 2, description_);
         }
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
           output.writeBytes(3, data_);
@@ -1186,7 +1283,7 @@ public final class Car {
             .computeEnumSize(1, type_);
         }
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          size += com.google.protobuf.GeneratedMessage.computeStringSize(2, description_);
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, description_);
         }
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
           size += com.google.protobuf.CodedOutputStream
@@ -1198,6 +1295,59 @@ public final class Car {
       }
 
       private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof chaintool.car.abi.Car.Archive.Signature)) {
+          return super.equals(obj);
+        }
+        chaintool.car.abi.Car.Archive.Signature other = (chaintool.car.abi.Car.Archive.Signature) obj;
+
+        boolean result = true;
+        result = result && (hasType() == other.hasType());
+        if (hasType()) {
+          result = result && type_ == other.type_;
+        }
+        result = result && (hasDescription() == other.hasDescription());
+        if (hasDescription()) {
+          result = result && getDescription()
+              .equals(other.getDescription());
+        }
+        result = result && (hasData() == other.hasData());
+        if (hasData()) {
+          result = result && getData()
+              .equals(other.getData());
+        }
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptorForType().hashCode();
+        if (hasType()) {
+          hash = (37 * hash) + TYPE_FIELD_NUMBER;
+          hash = (53 * hash) + type_;
+        }
+        if (hasDescription()) {
+          hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+          hash = (53 * hash) + getDescription().hashCode();
+        }
+        if (hasData()) {
+          hash = (37 * hash) + DATA_FIELD_NUMBER;
+          hash = (53 * hash) + getData().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
       public static chaintool.car.abi.Car.Archive.Signature parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1221,34 +1371,40 @@ public final class Car {
       }
       public static chaintool.car.abi.Car.Archive.Signature parseFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return PARSER.parseFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
       public static chaintool.car.abi.Car.Archive.Signature parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
       public static chaintool.car.abi.Car.Archive.Signature parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
       }
       public static chaintool.car.abi.Car.Archive.Signature parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
       public static chaintool.car.abi.Car.Archive.Signature parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
-        return PARSER.parseFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
       public static chaintool.car.abi.Car.Archive.Signature parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
 
       public Builder newBuilderForType() { return newBuilder(); }
@@ -1265,7 +1421,7 @@ public final class Car {
 
       @java.lang.Override
       protected Builder newBuilderForType(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         Builder builder = new Builder(parent);
         return builder;
       }
@@ -1273,7 +1429,7 @@ public final class Car {
        * Protobuf type {@code chaintool.car.abi.Archive.Signature}
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
           // @@protoc_insertion_point(builder_implements:chaintool.car.abi.Archive.Signature)
           chaintool.car.abi.Car.Archive.SignatureOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
@@ -1281,7 +1437,7 @@ public final class Car {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Signature_descriptor;
         }
 
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Signature_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
@@ -1294,12 +1450,13 @@ public final class Car {
         }
 
         private Builder(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
           super(parent);
           maybeForceBuilderInitialization();
         }
         private void maybeForceBuilderInitialization() {
-          if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
           }
         }
         public Builder clear() {
@@ -1351,6 +1508,32 @@ public final class Car {
           return result;
         }
 
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
         public Builder mergeFrom(com.google.protobuf.Message other) {
           if (other instanceof chaintool.car.abi.Car.Archive.Signature) {
             return mergeFrom((chaintool.car.abi.Car.Archive.Signature)other);
@@ -1391,7 +1574,7 @@ public final class Car {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
             parsedMessage = (chaintool.car.abi.Car.Archive.Signature) e.getUnfinishedMessage();
-            throw e;
+            throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
               mergeFrom(parsedMessage);
@@ -1547,6 +1730,16 @@ public final class Car {
           onChanged();
           return this;
         }
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
 
         // @@protoc_insertion_point(builder_scope:chaintool.car.abi.Archive.Signature)
       }
@@ -1567,16 +1760,7 @@ public final class Car {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-          try {
             return new Signature(input, extensionRegistry);
-          } catch (RuntimeException e) {
-            if (e.getCause() instanceof
-                com.google.protobuf.InvalidProtocolBufferException) {
-              throw (com.google.protobuf.InvalidProtocolBufferException)
-                  e.getCause();
-            }
-            throw e;
-          }
         }
       };
 
@@ -1640,11 +1824,11 @@ public final class Car {
      * Protobuf type {@code chaintool.car.abi.Archive.Payload}
      */
     public  static final class Payload extends
-        com.google.protobuf.GeneratedMessage implements
+        com.google.protobuf.GeneratedMessageV3 implements
         // @@protoc_insertion_point(message_implements:chaintool.car.abi.Archive.Payload)
         PayloadOrBuilder {
       // Use Payload.newBuilder() to construct.
-      private Payload(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      private Payload(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
       }
       private Payload() {
@@ -1658,7 +1842,8 @@ public final class Car {
       }
       private Payload(
           com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
         this();
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -1683,7 +1868,7 @@ public final class Car {
                 if (((bitField0_ & 0x00000001) == 0x00000001)) {
                   subBuilder = compression_.toBuilder();
                 }
-                compression_ = input.readMessage(chaintool.car.abi.Car.Archive.Payload.Compression.parser(), extensionRegistry);
+                compression_ = input.readMessage(chaintool.car.abi.Car.Archive.Payload.Compression.PARSER, extensionRegistry);
                 if (subBuilder != null) {
                   subBuilder.mergeFrom(compression_);
                   compression_ = subBuilder.buildPartial();
@@ -1696,17 +1881,17 @@ public final class Car {
                   entries_ = new java.util.ArrayList<chaintool.car.abi.Car.Archive.Payload.Entries>();
                   mutable_bitField0_ |= 0x00000002;
                 }
-                entries_.add(input.readMessage(chaintool.car.abi.Car.Archive.Payload.Entries.parser(), extensionRegistry));
+                entries_.add(
+                    input.readMessage(chaintool.car.abi.Car.Archive.Payload.Entries.PARSER, extensionRegistry));
                 break;
               }
             }
           }
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw new RuntimeException(e.setUnfinishedMessage(this));
+          throw e.setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
-          throw new RuntimeException(
-              new com.google.protobuf.InvalidProtocolBufferException(
-                  e.getMessage()).setUnfinishedMessage(this));
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
         } finally {
           if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
             entries_ = java.util.Collections.unmodifiableList(entries_);
@@ -1720,7 +1905,7 @@ public final class Car {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1758,11 +1943,11 @@ public final class Car {
        * Protobuf type {@code chaintool.car.abi.Archive.Payload.Compression}
        */
       public  static final class Compression extends
-          com.google.protobuf.GeneratedMessage implements
+          com.google.protobuf.GeneratedMessageV3 implements
           // @@protoc_insertion_point(message_implements:chaintool.car.abi.Archive.Payload.Compression)
           CompressionOrBuilder {
         // Use Compression.newBuilder() to construct.
-        private Compression(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+        private Compression(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
           super(builder);
         }
         private Compression() {
@@ -1777,7 +1962,8 @@ public final class Car {
         }
         private Compression(
             com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
           this();
           int mutable_bitField0_ = 0;
           com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -1817,11 +2003,10 @@ public final class Car {
               }
             }
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw new RuntimeException(e.setUnfinishedMessage(this));
+            throw e.setUnfinishedMessage(this);
           } catch (java.io.IOException e) {
-            throw new RuntimeException(
-                new com.google.protobuf.InvalidProtocolBufferException(
-                    e.getMessage()).setUnfinishedMessage(this));
+            throw new com.google.protobuf.InvalidProtocolBufferException(
+                e).setUnfinishedMessage(this);
           } finally {
             this.unknownFields = unknownFields.build();
             makeExtensionsImmutable();
@@ -1832,7 +2017,7 @@ public final class Car {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Compression_descriptor;
         }
 
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Compression_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
@@ -1847,23 +2032,23 @@ public final class Car {
           /**
            * <code>NONE = 1;</code>
            */
-          NONE(0, 1),
+          NONE(1),
           /**
            * <code>GZIP = 2;</code>
            */
-          GZIP(1, 2),
+          GZIP(2),
           /**
            * <code>LZMA = 3;</code>
            */
-          LZMA(2, 3),
+          LZMA(3),
           /**
            * <code>BZIP2 = 4;</code>
            */
-          BZIP2(3, 4),
+          BZIP2(4),
           /**
            * <code>XZ = 5;</code>
            */
-          XZ(4, 5),
+          XZ(5),
           ;
 
           /**
@@ -1892,7 +2077,15 @@ public final class Car {
             return value;
           }
 
+          /**
+           * @deprecated Use {@link #forNumber(int)} instead.
+           */
+          @java.lang.Deprecated
           public static Type valueOf(int value) {
+            return forNumber(value);
+          }
+
+          public static Type forNumber(int value) {
             switch (value) {
               case 1: return NONE;
               case 2: return GZIP;
@@ -1911,13 +2104,13 @@ public final class Car {
               Type> internalValueMap =
                 new com.google.protobuf.Internal.EnumLiteMap<Type>() {
                   public Type findValueByNumber(int number) {
-                    return Type.valueOf(number);
+                    return Type.forNumber(number);
                   }
                 };
 
           public final com.google.protobuf.Descriptors.EnumValueDescriptor
               getValueDescriptor() {
-            return getDescriptor().getValues().get(index);
+            return getDescriptor().getValues().get(ordinal());
           }
           public final com.google.protobuf.Descriptors.EnumDescriptor
               getDescriptorForType() {
@@ -1939,11 +2132,9 @@ public final class Car {
             return VALUES[desc.getIndex()];
           }
 
-          private final int index;
           private final int value;
 
-          private Type(int index, int value) {
-            this.index = index;
+          private Type(int value) {
             this.value = value;
           }
 
@@ -2025,7 +2216,7 @@ public final class Car {
             output.writeEnum(1, type_);
           }
           if (((bitField0_ & 0x00000002) == 0x00000002)) {
-            com.google.protobuf.GeneratedMessage.writeString(output, 2, description_);
+            com.google.protobuf.GeneratedMessageV3.writeString(output, 2, description_);
           }
           unknownFields.writeTo(output);
         }
@@ -2040,7 +2231,7 @@ public final class Car {
               .computeEnumSize(1, type_);
           }
           if (((bitField0_ & 0x00000002) == 0x00000002)) {
-            size += com.google.protobuf.GeneratedMessage.computeStringSize(2, description_);
+            size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, description_);
           }
           size += unknownFields.getSerializedSize();
           memoizedSize = size;
@@ -2048,6 +2239,50 @@ public final class Car {
         }
 
         private static final long serialVersionUID = 0L;
+        @java.lang.Override
+        public boolean equals(final java.lang.Object obj) {
+          if (obj == this) {
+           return true;
+          }
+          if (!(obj instanceof chaintool.car.abi.Car.Archive.Payload.Compression)) {
+            return super.equals(obj);
+          }
+          chaintool.car.abi.Car.Archive.Payload.Compression other = (chaintool.car.abi.Car.Archive.Payload.Compression) obj;
+
+          boolean result = true;
+          result = result && (hasType() == other.hasType());
+          if (hasType()) {
+            result = result && type_ == other.type_;
+          }
+          result = result && (hasDescription() == other.hasDescription());
+          if (hasDescription()) {
+            result = result && getDescription()
+                .equals(other.getDescription());
+          }
+          result = result && unknownFields.equals(other.unknownFields);
+          return result;
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+          if (memoizedHashCode != 0) {
+            return memoizedHashCode;
+          }
+          int hash = 41;
+          hash = (19 * hash) + getDescriptorForType().hashCode();
+          if (hasType()) {
+            hash = (37 * hash) + TYPE_FIELD_NUMBER;
+            hash = (53 * hash) + type_;
+          }
+          if (hasDescription()) {
+            hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+            hash = (53 * hash) + getDescription().hashCode();
+          }
+          hash = (29 * hash) + unknownFields.hashCode();
+          memoizedHashCode = hash;
+          return hash;
+        }
+
         public static chaintool.car.abi.Car.Archive.Payload.Compression parseFrom(
             com.google.protobuf.ByteString data)
             throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2071,34 +2306,40 @@ public final class Car {
         }
         public static chaintool.car.abi.Car.Archive.Payload.Compression parseFrom(java.io.InputStream input)
             throws java.io.IOException {
-          return PARSER.parseFrom(input);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Compression parseFrom(
             java.io.InputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          return PARSER.parseFrom(input, extensionRegistry);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input, extensionRegistry);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Compression parseDelimitedFrom(java.io.InputStream input)
             throws java.io.IOException {
-          return PARSER.parseDelimitedFrom(input);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseDelimitedWithIOException(PARSER, input);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Compression parseDelimitedFrom(
             java.io.InputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          return PARSER.parseDelimitedFrom(input, extensionRegistry);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Compression parseFrom(
             com.google.protobuf.CodedInputStream input)
             throws java.io.IOException {
-          return PARSER.parseFrom(input);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Compression parseFrom(
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          return PARSER.parseFrom(input, extensionRegistry);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input, extensionRegistry);
         }
 
         public Builder newBuilderForType() { return newBuilder(); }
@@ -2115,7 +2356,7 @@ public final class Car {
 
         @java.lang.Override
         protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
           Builder builder = new Builder(parent);
           return builder;
         }
@@ -2123,7 +2364,7 @@ public final class Car {
          * Protobuf type {@code chaintool.car.abi.Archive.Payload.Compression}
          */
         public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
             // @@protoc_insertion_point(builder_implements:chaintool.car.abi.Archive.Payload.Compression)
             chaintool.car.abi.Car.Archive.Payload.CompressionOrBuilder {
           public static final com.google.protobuf.Descriptors.Descriptor
@@ -2131,7 +2372,7 @@ public final class Car {
             return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Compression_descriptor;
           }
 
-          protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
               internalGetFieldAccessorTable() {
             return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Compression_fieldAccessorTable
                 .ensureFieldAccessorsInitialized(
@@ -2144,12 +2385,13 @@ public final class Car {
           }
 
           private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
             super(parent);
             maybeForceBuilderInitialization();
           }
           private void maybeForceBuilderInitialization() {
-            if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            if (com.google.protobuf.GeneratedMessageV3
+                    .alwaysUseFieldBuilders) {
             }
           }
           public Builder clear() {
@@ -2195,6 +2437,32 @@ public final class Car {
             return result;
           }
 
+          public Builder clone() {
+            return (Builder) super.clone();
+          }
+          public Builder setField(
+              com.google.protobuf.Descriptors.FieldDescriptor field,
+              Object value) {
+            return (Builder) super.setField(field, value);
+          }
+          public Builder clearField(
+              com.google.protobuf.Descriptors.FieldDescriptor field) {
+            return (Builder) super.clearField(field);
+          }
+          public Builder clearOneof(
+              com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+            return (Builder) super.clearOneof(oneof);
+          }
+          public Builder setRepeatedField(
+              com.google.protobuf.Descriptors.FieldDescriptor field,
+              int index, Object value) {
+            return (Builder) super.setRepeatedField(field, index, value);
+          }
+          public Builder addRepeatedField(
+              com.google.protobuf.Descriptors.FieldDescriptor field,
+              Object value) {
+            return (Builder) super.addRepeatedField(field, value);
+          }
           public Builder mergeFrom(com.google.protobuf.Message other) {
             if (other instanceof chaintool.car.abi.Car.Archive.Payload.Compression) {
               return mergeFrom((chaintool.car.abi.Car.Archive.Payload.Compression)other);
@@ -2232,7 +2500,7 @@ public final class Car {
               parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
             } catch (com.google.protobuf.InvalidProtocolBufferException e) {
               parsedMessage = (chaintool.car.abi.Car.Archive.Payload.Compression) e.getUnfinishedMessage();
-              throw e;
+              throw e.unwrapIOException();
             } finally {
               if (parsedMessage != null) {
                 mergeFrom(parsedMessage);
@@ -2353,6 +2621,16 @@ public final class Car {
             onChanged();
             return this;
           }
+          public final Builder setUnknownFields(
+              final com.google.protobuf.UnknownFieldSet unknownFields) {
+            return super.setUnknownFields(unknownFields);
+          }
+
+          public final Builder mergeUnknownFields(
+              final com.google.protobuf.UnknownFieldSet unknownFields) {
+            return super.mergeUnknownFields(unknownFields);
+          }
+
 
           // @@protoc_insertion_point(builder_scope:chaintool.car.abi.Archive.Payload.Compression)
         }
@@ -2373,16 +2651,7 @@ public final class Car {
               com.google.protobuf.CodedInputStream input,
               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
               throws com.google.protobuf.InvalidProtocolBufferException {
-            try {
               return new Compression(input, extensionRegistry);
-            } catch (RuntimeException e) {
-              if (e.getCause() instanceof
-                  com.google.protobuf.InvalidProtocolBufferException) {
-                throw (com.google.protobuf.InvalidProtocolBufferException)
-                    e.getCause();
-              }
-              throw e;
-            }
           }
         };
 
@@ -2455,11 +2724,11 @@ public final class Car {
        * Protobuf type {@code chaintool.car.abi.Archive.Payload.Entries}
        */
       public  static final class Entries extends
-          com.google.protobuf.GeneratedMessage implements
+          com.google.protobuf.GeneratedMessageV3 implements
           // @@protoc_insertion_point(message_implements:chaintool.car.abi.Archive.Payload.Entries)
           EntriesOrBuilder {
         // Use Entries.newBuilder() to construct.
-        private Entries(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+        private Entries(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
           super(builder);
         }
         private Entries() {
@@ -2476,7 +2745,8 @@ public final class Car {
         }
         private Entries(
             com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
           this();
           int mutable_bitField0_ = 0;
           com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -2521,11 +2791,10 @@ public final class Car {
               }
             }
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw new RuntimeException(e.setUnfinishedMessage(this));
+            throw e.setUnfinishedMessage(this);
           } catch (java.io.IOException e) {
-            throw new RuntimeException(
-                new com.google.protobuf.InvalidProtocolBufferException(
-                    e.getMessage()).setUnfinishedMessage(this));
+            throw new com.google.protobuf.InvalidProtocolBufferException(
+                e).setUnfinishedMessage(this);
           } finally {
             this.unknownFields = unknownFields.build();
             makeExtensionsImmutable();
@@ -2536,7 +2805,7 @@ public final class Car {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Entries_descriptor;
         }
 
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Entries_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
@@ -2671,13 +2940,13 @@ public final class Car {
         public void writeTo(com.google.protobuf.CodedOutputStream output)
                             throws java.io.IOException {
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            com.google.protobuf.GeneratedMessage.writeString(output, 1, path_);
+            com.google.protobuf.GeneratedMessageV3.writeString(output, 1, path_);
           }
           if (((bitField0_ & 0x00000002) == 0x00000002)) {
             output.writeUInt64(2, size_);
           }
           if (((bitField0_ & 0x00000004) == 0x00000004)) {
-            com.google.protobuf.GeneratedMessage.writeString(output, 3, sha1_);
+            com.google.protobuf.GeneratedMessageV3.writeString(output, 3, sha1_);
           }
           if (((bitField0_ & 0x00000008) == 0x00000008)) {
             output.writeBytes(16, data_);
@@ -2691,14 +2960,14 @@ public final class Car {
 
           size = 0;
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            size += com.google.protobuf.GeneratedMessage.computeStringSize(1, path_);
+            size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, path_);
           }
           if (((bitField0_ & 0x00000002) == 0x00000002)) {
             size += com.google.protobuf.CodedOutputStream
               .computeUInt64Size(2, size_);
           }
           if (((bitField0_ & 0x00000004) == 0x00000004)) {
-            size += com.google.protobuf.GeneratedMessage.computeStringSize(3, sha1_);
+            size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, sha1_);
           }
           if (((bitField0_ & 0x00000008) == 0x00000008)) {
             size += com.google.protobuf.CodedOutputStream
@@ -2710,6 +2979,70 @@ public final class Car {
         }
 
         private static final long serialVersionUID = 0L;
+        @java.lang.Override
+        public boolean equals(final java.lang.Object obj) {
+          if (obj == this) {
+           return true;
+          }
+          if (!(obj instanceof chaintool.car.abi.Car.Archive.Payload.Entries)) {
+            return super.equals(obj);
+          }
+          chaintool.car.abi.Car.Archive.Payload.Entries other = (chaintool.car.abi.Car.Archive.Payload.Entries) obj;
+
+          boolean result = true;
+          result = result && (hasPath() == other.hasPath());
+          if (hasPath()) {
+            result = result && getPath()
+                .equals(other.getPath());
+          }
+          result = result && (hasSize() == other.hasSize());
+          if (hasSize()) {
+            result = result && (getSize()
+                == other.getSize());
+          }
+          result = result && (hasSha1() == other.hasSha1());
+          if (hasSha1()) {
+            result = result && getSha1()
+                .equals(other.getSha1());
+          }
+          result = result && (hasData() == other.hasData());
+          if (hasData()) {
+            result = result && getData()
+                .equals(other.getData());
+          }
+          result = result && unknownFields.equals(other.unknownFields);
+          return result;
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+          if (memoizedHashCode != 0) {
+            return memoizedHashCode;
+          }
+          int hash = 41;
+          hash = (19 * hash) + getDescriptorForType().hashCode();
+          if (hasPath()) {
+            hash = (37 * hash) + PATH_FIELD_NUMBER;
+            hash = (53 * hash) + getPath().hashCode();
+          }
+          if (hasSize()) {
+            hash = (37 * hash) + SIZE_FIELD_NUMBER;
+            hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+                getSize());
+          }
+          if (hasSha1()) {
+            hash = (37 * hash) + SHA1_FIELD_NUMBER;
+            hash = (53 * hash) + getSha1().hashCode();
+          }
+          if (hasData()) {
+            hash = (37 * hash) + DATA_FIELD_NUMBER;
+            hash = (53 * hash) + getData().hashCode();
+          }
+          hash = (29 * hash) + unknownFields.hashCode();
+          memoizedHashCode = hash;
+          return hash;
+        }
+
         public static chaintool.car.abi.Car.Archive.Payload.Entries parseFrom(
             com.google.protobuf.ByteString data)
             throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2733,34 +3066,40 @@ public final class Car {
         }
         public static chaintool.car.abi.Car.Archive.Payload.Entries parseFrom(java.io.InputStream input)
             throws java.io.IOException {
-          return PARSER.parseFrom(input);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Entries parseFrom(
             java.io.InputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          return PARSER.parseFrom(input, extensionRegistry);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input, extensionRegistry);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Entries parseDelimitedFrom(java.io.InputStream input)
             throws java.io.IOException {
-          return PARSER.parseDelimitedFrom(input);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseDelimitedWithIOException(PARSER, input);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Entries parseDelimitedFrom(
             java.io.InputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          return PARSER.parseDelimitedFrom(input, extensionRegistry);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Entries parseFrom(
             com.google.protobuf.CodedInputStream input)
             throws java.io.IOException {
-          return PARSER.parseFrom(input);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input);
         }
         public static chaintool.car.abi.Car.Archive.Payload.Entries parseFrom(
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          return PARSER.parseFrom(input, extensionRegistry);
+          return com.google.protobuf.GeneratedMessageV3
+              .parseWithIOException(PARSER, input, extensionRegistry);
         }
 
         public Builder newBuilderForType() { return newBuilder(); }
@@ -2777,7 +3116,7 @@ public final class Car {
 
         @java.lang.Override
         protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
           Builder builder = new Builder(parent);
           return builder;
         }
@@ -2785,7 +3124,7 @@ public final class Car {
          * Protobuf type {@code chaintool.car.abi.Archive.Payload.Entries}
          */
         public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
             // @@protoc_insertion_point(builder_implements:chaintool.car.abi.Archive.Payload.Entries)
             chaintool.car.abi.Car.Archive.Payload.EntriesOrBuilder {
           public static final com.google.protobuf.Descriptors.Descriptor
@@ -2793,7 +3132,7 @@ public final class Car {
             return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Entries_descriptor;
           }
 
-          protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
               internalGetFieldAccessorTable() {
             return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_Entries_fieldAccessorTable
                 .ensureFieldAccessorsInitialized(
@@ -2806,12 +3145,13 @@ public final class Car {
           }
 
           private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
             super(parent);
             maybeForceBuilderInitialization();
           }
           private void maybeForceBuilderInitialization() {
-            if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            if (com.google.protobuf.GeneratedMessageV3
+                    .alwaysUseFieldBuilders) {
             }
           }
           public Builder clear() {
@@ -2869,6 +3209,32 @@ public final class Car {
             return result;
           }
 
+          public Builder clone() {
+            return (Builder) super.clone();
+          }
+          public Builder setField(
+              com.google.protobuf.Descriptors.FieldDescriptor field,
+              Object value) {
+            return (Builder) super.setField(field, value);
+          }
+          public Builder clearField(
+              com.google.protobuf.Descriptors.FieldDescriptor field) {
+            return (Builder) super.clearField(field);
+          }
+          public Builder clearOneof(
+              com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+            return (Builder) super.clearOneof(oneof);
+          }
+          public Builder setRepeatedField(
+              com.google.protobuf.Descriptors.FieldDescriptor field,
+              int index, Object value) {
+            return (Builder) super.setRepeatedField(field, index, value);
+          }
+          public Builder addRepeatedField(
+              com.google.protobuf.Descriptors.FieldDescriptor field,
+              Object value) {
+            return (Builder) super.addRepeatedField(field, value);
+          }
           public Builder mergeFrom(com.google.protobuf.Message other) {
             if (other instanceof chaintool.car.abi.Car.Archive.Payload.Entries) {
               return mergeFrom((chaintool.car.abi.Car.Archive.Payload.Entries)other);
@@ -2914,7 +3280,7 @@ public final class Car {
               parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
             } catch (com.google.protobuf.InvalidProtocolBufferException e) {
               parsedMessage = (chaintool.car.abi.Car.Archive.Payload.Entries) e.getUnfinishedMessage();
-              throw e;
+              throw e.unwrapIOException();
             } finally {
               if (parsedMessage != null) {
                 mergeFrom(parsedMessage);
@@ -3142,6 +3508,16 @@ public final class Car {
             onChanged();
             return this;
           }
+          public final Builder setUnknownFields(
+              final com.google.protobuf.UnknownFieldSet unknownFields) {
+            return super.setUnknownFields(unknownFields);
+          }
+
+          public final Builder mergeUnknownFields(
+              final com.google.protobuf.UnknownFieldSet unknownFields) {
+            return super.mergeUnknownFields(unknownFields);
+          }
+
 
           // @@protoc_insertion_point(builder_scope:chaintool.car.abi.Archive.Payload.Entries)
         }
@@ -3162,16 +3538,7 @@ public final class Car {
               com.google.protobuf.CodedInputStream input,
               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
               throws com.google.protobuf.InvalidProtocolBufferException {
-            try {
               return new Entries(input, extensionRegistry);
-            } catch (RuntimeException e) {
-              if (e.getCause() instanceof
-                  com.google.protobuf.InvalidProtocolBufferException) {
-                throw (com.google.protobuf.InvalidProtocolBufferException)
-                    e.getCause();
-              }
-              throw e;
-            }
           }
         };
 
@@ -3287,6 +3654,48 @@ public final class Car {
       }
 
       private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof chaintool.car.abi.Car.Archive.Payload)) {
+          return super.equals(obj);
+        }
+        chaintool.car.abi.Car.Archive.Payload other = (chaintool.car.abi.Car.Archive.Payload) obj;
+
+        boolean result = true;
+        result = result && (hasCompression() == other.hasCompression());
+        if (hasCompression()) {
+          result = result && getCompression()
+              .equals(other.getCompression());
+        }
+        result = result && getEntriesList()
+            .equals(other.getEntriesList());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptorForType().hashCode();
+        if (hasCompression()) {
+          hash = (37 * hash) + COMPRESSION_FIELD_NUMBER;
+          hash = (53 * hash) + getCompression().hashCode();
+        }
+        if (getEntriesCount() > 0) {
+          hash = (37 * hash) + ENTRIES_FIELD_NUMBER;
+          hash = (53 * hash) + getEntriesList().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
       public static chaintool.car.abi.Car.Archive.Payload parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
@@ -3310,34 +3719,40 @@ public final class Car {
       }
       public static chaintool.car.abi.Car.Archive.Payload parseFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return PARSER.parseFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
       public static chaintool.car.abi.Car.Archive.Payload parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
       public static chaintool.car.abi.Car.Archive.Payload parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
       }
       public static chaintool.car.abi.Car.Archive.Payload parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
       public static chaintool.car.abi.Car.Archive.Payload parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
-        return PARSER.parseFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
       public static chaintool.car.abi.Car.Archive.Payload parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
 
       public Builder newBuilderForType() { return newBuilder(); }
@@ -3354,7 +3769,7 @@ public final class Car {
 
       @java.lang.Override
       protected Builder newBuilderForType(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         Builder builder = new Builder(parent);
         return builder;
       }
@@ -3362,7 +3777,7 @@ public final class Car {
        * Protobuf type {@code chaintool.car.abi.Archive.Payload}
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
           // @@protoc_insertion_point(builder_implements:chaintool.car.abi.Archive.Payload)
           chaintool.car.abi.Car.Archive.PayloadOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
@@ -3370,7 +3785,7 @@ public final class Car {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_descriptor;
         }
 
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
           return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_Payload_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
@@ -3383,12 +3798,13 @@ public final class Car {
         }
 
         private Builder(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
           super(parent);
           maybeForceBuilderInitialization();
         }
         private void maybeForceBuilderInitialization() {
-          if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
             getCompressionFieldBuilder();
             getEntriesFieldBuilder();
           }
@@ -3453,6 +3869,32 @@ public final class Car {
           return result;
         }
 
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
         public Builder mergeFrom(com.google.protobuf.Message other) {
           if (other instanceof chaintool.car.abi.Car.Archive.Payload) {
             return mergeFrom((chaintool.car.abi.Car.Archive.Payload)other);
@@ -3486,7 +3928,7 @@ public final class Car {
                 entries_ = other.entries_;
                 bitField0_ = (bitField0_ & ~0x00000002);
                 entriesBuilder_ = 
-                  com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                  com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                      getEntriesFieldBuilder() : null;
               } else {
                 entriesBuilder_.addAllMessages(other.entries_);
@@ -3511,7 +3953,7 @@ public final class Car {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
             parsedMessage = (chaintool.car.abi.Car.Archive.Payload) e.getUnfinishedMessage();
-            throw e;
+            throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
               mergeFrom(parsedMessage);
@@ -3522,7 +3964,7 @@ public final class Car {
         private int bitField0_;
 
         private chaintool.car.abi.Car.Archive.Payload.Compression compression_ = null;
-        private com.google.protobuf.SingleFieldBuilder<
+        private com.google.protobuf.SingleFieldBuilderV3<
             chaintool.car.abi.Car.Archive.Payload.Compression, chaintool.car.abi.Car.Archive.Payload.Compression.Builder, chaintool.car.abi.Car.Archive.Payload.CompressionOrBuilder> compressionBuilder_;
         /**
          * <code>optional .chaintool.car.abi.Archive.Payload.Compression compression = 1;</code>
@@ -3625,11 +4067,11 @@ public final class Car {
         /**
          * <code>optional .chaintool.car.abi.Archive.Payload.Compression compression = 1;</code>
          */
-        private com.google.protobuf.SingleFieldBuilder<
+        private com.google.protobuf.SingleFieldBuilderV3<
             chaintool.car.abi.Car.Archive.Payload.Compression, chaintool.car.abi.Car.Archive.Payload.Compression.Builder, chaintool.car.abi.Car.Archive.Payload.CompressionOrBuilder> 
             getCompressionFieldBuilder() {
           if (compressionBuilder_ == null) {
-            compressionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+            compressionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
                 chaintool.car.abi.Car.Archive.Payload.Compression, chaintool.car.abi.Car.Archive.Payload.Compression.Builder, chaintool.car.abi.Car.Archive.Payload.CompressionOrBuilder>(
                     getCompression(),
                     getParentForChildren(),
@@ -3648,7 +4090,7 @@ public final class Car {
            }
         }
 
-        private com.google.protobuf.RepeatedFieldBuilder<
+        private com.google.protobuf.RepeatedFieldBuilderV3<
             chaintool.car.abi.Car.Archive.Payload.Entries, chaintool.car.abi.Car.Archive.Payload.Entries.Builder, chaintool.car.abi.Car.Archive.Payload.EntriesOrBuilder> entriesBuilder_;
 
         /**
@@ -3864,11 +4306,11 @@ public final class Car {
              getEntriesBuilderList() {
           return getEntriesFieldBuilder().getBuilderList();
         }
-        private com.google.protobuf.RepeatedFieldBuilder<
+        private com.google.protobuf.RepeatedFieldBuilderV3<
             chaintool.car.abi.Car.Archive.Payload.Entries, chaintool.car.abi.Car.Archive.Payload.Entries.Builder, chaintool.car.abi.Car.Archive.Payload.EntriesOrBuilder> 
             getEntriesFieldBuilder() {
           if (entriesBuilder_ == null) {
-            entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+            entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
                 chaintool.car.abi.Car.Archive.Payload.Entries, chaintool.car.abi.Car.Archive.Payload.Entries.Builder, chaintool.car.abi.Car.Archive.Payload.EntriesOrBuilder>(
                     entries_,
                     ((bitField0_ & 0x00000002) == 0x00000002),
@@ -3878,6 +4320,16 @@ public final class Car {
           }
           return entriesBuilder_;
         }
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
 
         // @@protoc_insertion_point(builder_scope:chaintool.car.abi.Archive.Payload)
       }
@@ -3898,16 +4350,7 @@ public final class Car {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-          try {
             return new Payload(input, extensionRegistry);
-          } catch (RuntimeException e) {
-            if (e.getCause() instanceof
-                com.google.protobuf.InvalidProtocolBufferException) {
-              throw (com.google.protobuf.InvalidProtocolBufferException)
-                  e.getCause();
-            }
-            throw e;
-          }
         }
       };
 
@@ -4003,6 +4446,51 @@ public final class Car {
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof chaintool.car.abi.Car.Archive)) {
+        return super.equals(obj);
+      }
+      chaintool.car.abi.Car.Archive other = (chaintool.car.abi.Car.Archive) obj;
+
+      boolean result = true;
+      result = result && (hasSignature() == other.hasSignature());
+      if (hasSignature()) {
+        result = result && getSignature()
+            .equals(other.getSignature());
+      }
+      result = result && (hasPayload() == other.hasPayload());
+      if (hasPayload()) {
+        result = result && getPayload()
+            .equals(other.getPayload());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (hasSignature()) {
+        hash = (37 * hash) + SIGNATURE_FIELD_NUMBER;
+        hash = (53 * hash) + getSignature().hashCode();
+      }
+      if (hasPayload()) {
+        hash = (37 * hash) + PAYLOAD_FIELD_NUMBER;
+        hash = (53 * hash) + getPayload().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static chaintool.car.abi.Car.Archive parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -4026,34 +4514,40 @@ public final class Car {
     }
     public static chaintool.car.abi.Car.Archive parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static chaintool.car.abi.Car.Archive parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static chaintool.car.abi.Car.Archive parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static chaintool.car.abi.Car.Archive parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static chaintool.car.abi.Car.Archive parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static chaintool.car.abi.Car.Archive parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -4070,7 +4564,7 @@ public final class Car {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -4078,7 +4572,7 @@ public final class Car {
      * Protobuf type {@code chaintool.car.abi.Archive}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:chaintool.car.abi.Archive)
         chaintool.car.abi.Car.ArchiveOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -4086,7 +4580,7 @@ public final class Car {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return chaintool.car.abi.Car.internal_static_chaintool_car_abi_Archive_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -4099,12 +4593,13 @@ public final class Car {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getSignatureFieldBuilder();
         }
       }
@@ -4159,6 +4654,32 @@ public final class Car {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof chaintool.car.abi.Car.Archive) {
           return mergeFrom((chaintool.car.abi.Car.Archive)other);
@@ -4194,7 +4715,7 @@ public final class Car {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (chaintool.car.abi.Car.Archive) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -4205,7 +4726,7 @@ public final class Car {
       private int bitField0_;
 
       private chaintool.car.abi.Car.Archive.Signature signature_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           chaintool.car.abi.Car.Archive.Signature, chaintool.car.abi.Car.Archive.Signature.Builder, chaintool.car.abi.Car.Archive.SignatureOrBuilder> signatureBuilder_;
       /**
        * <code>optional .chaintool.car.abi.Archive.Signature signature = 1;</code>
@@ -4308,11 +4829,11 @@ public final class Car {
       /**
        * <code>optional .chaintool.car.abi.Archive.Signature signature = 1;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           chaintool.car.abi.Car.Archive.Signature, chaintool.car.abi.Car.Archive.Signature.Builder, chaintool.car.abi.Car.Archive.SignatureOrBuilder> 
           getSignatureFieldBuilder() {
         if (signatureBuilder_ == null) {
-          signatureBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          signatureBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               chaintool.car.abi.Car.Archive.Signature, chaintool.car.abi.Car.Archive.Signature.Builder, chaintool.car.abi.Car.Archive.SignatureOrBuilder>(
                   getSignature(),
                   getParentForChildren(),
@@ -4356,6 +4877,16 @@ public final class Car {
         onChanged();
         return this;
       }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:chaintool.car.abi.Archive)
     }
@@ -4376,16 +4907,7 @@ public final class Car {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new Archive(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -4404,42 +4926,42 @@ public final class Car {
 
   }
 
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_chaintool_car_abi_CompatibilityHeader_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_chaintool_car_abi_CompatibilityHeader_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_chaintool_car_abi_Archive_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_chaintool_car_abi_Archive_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_chaintool_car_abi_Archive_Signature_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_chaintool_car_abi_Archive_Signature_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_chaintool_car_abi_Archive_Payload_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_chaintool_car_abi_Archive_Payload_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_chaintool_car_abi_Archive_Payload_Compression_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_chaintool_car_abi_Archive_Payload_Compression_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_chaintool_car_abi_Archive_Payload_Entries_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_chaintool_car_abi_Archive_Payload_Entries_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
   }
-  private static com.google.protobuf.Descriptors.FileDescriptor
+  private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {
@@ -4477,37 +4999,37 @@ public final class Car {
     internal_static_chaintool_car_abi_CompatibilityHeader_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_chaintool_car_abi_CompatibilityHeader_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_chaintool_car_abi_CompatibilityHeader_descriptor,
         new java.lang.String[] { "Magic", "Version", "Features", });
     internal_static_chaintool_car_abi_Archive_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_chaintool_car_abi_Archive_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_chaintool_car_abi_Archive_descriptor,
         new java.lang.String[] { "Signature", "Payload", });
     internal_static_chaintool_car_abi_Archive_Signature_descriptor =
       internal_static_chaintool_car_abi_Archive_descriptor.getNestedTypes().get(0);
     internal_static_chaintool_car_abi_Archive_Signature_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_chaintool_car_abi_Archive_Signature_descriptor,
         new java.lang.String[] { "Type", "Description", "Data", });
     internal_static_chaintool_car_abi_Archive_Payload_descriptor =
       internal_static_chaintool_car_abi_Archive_descriptor.getNestedTypes().get(1);
     internal_static_chaintool_car_abi_Archive_Payload_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_chaintool_car_abi_Archive_Payload_descriptor,
         new java.lang.String[] { "Compression", "Entries", });
     internal_static_chaintool_car_abi_Archive_Payload_Compression_descriptor =
       internal_static_chaintool_car_abi_Archive_Payload_descriptor.getNestedTypes().get(0);
     internal_static_chaintool_car_abi_Archive_Payload_Compression_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_chaintool_car_abi_Archive_Payload_Compression_descriptor,
         new java.lang.String[] { "Type", "Description", });
     internal_static_chaintool_car_abi_Archive_Payload_Entries_descriptor =
       internal_static_chaintool_car_abi_Archive_Payload_descriptor.getNestedTypes().get(1);
     internal_static_chaintool_car_abi_Archive_Payload_Entries_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_chaintool_car_abi_Archive_Payload_Entries_descriptor,
         new java.lang.String[] { "Path", "Size", "Sha1", "Data", });
   }

--- a/src/org/hyperledger/chaintool/meta/OrgHyperledgerChaintoolMeta.java
+++ b/src/org/hyperledger/chaintool/meta/OrgHyperledgerChaintoolMeta.java
@@ -6,7 +6,13 @@ package org.hyperledger.chaintool.meta;
 public final class OrgHyperledgerChaintoolMeta {
   private OrgHyperledgerChaintoolMeta() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface InterfaceDescriptorOrBuilder extends
       // @@protoc_insertion_point(interface_extends:org.hyperledger.chaintool.meta.InterfaceDescriptor)
@@ -31,11 +37,11 @@ public final class OrgHyperledgerChaintoolMeta {
    * Protobuf type {@code org.hyperledger.chaintool.meta.InterfaceDescriptor}
    */
   public  static final class InterfaceDescriptor extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:org.hyperledger.chaintool.meta.InterfaceDescriptor)
       InterfaceDescriptorOrBuilder {
     // Use InterfaceDescriptor.newBuilder() to construct.
-    private InterfaceDescriptor(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private InterfaceDescriptor(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private InterfaceDescriptor() {
@@ -50,7 +56,8 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     private InterfaceDescriptor(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       int mutable_bitField0_ = 0;
       try {
@@ -81,11 +88,10 @@ public final class OrgHyperledgerChaintoolMeta {
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         makeExtensionsImmutable();
       }
@@ -95,7 +101,7 @@ public final class OrgHyperledgerChaintoolMeta {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -158,7 +164,7 @@ public final class OrgHyperledgerChaintoolMeta {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getNameBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
       if (!data_.isEmpty()) {
         output.writeBytes(2, data_);
@@ -171,7 +177,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
       size = 0;
       if (!getNameBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
       if (!data_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
@@ -182,6 +188,40 @@ public final class OrgHyperledgerChaintoolMeta {
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor)) {
+        return super.equals(obj);
+      }
+      org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor other = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor) obj;
+
+      boolean result = true;
+      result = result && getName()
+          .equals(other.getName());
+      result = result && getData()
+          .equals(other.getData());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getName().hashCode();
+      hash = (37 * hash) + DATA_FIELD_NUMBER;
+      hash = (53 * hash) + getData().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -205,34 +245,40 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -249,7 +295,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -257,7 +303,7 @@ public final class OrgHyperledgerChaintoolMeta {
      * Protobuf type {@code org.hyperledger.chaintool.meta.InterfaceDescriptor}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.hyperledger.chaintool.meta.InterfaceDescriptor)
         org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -265,7 +311,7 @@ public final class OrgHyperledgerChaintoolMeta {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -278,12 +324,13 @@ public final class OrgHyperledgerChaintoolMeta {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -320,6 +367,32 @@ public final class OrgHyperledgerChaintoolMeta {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor) {
           return mergeFrom((org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor)other);
@@ -355,7 +428,7 @@ public final class OrgHyperledgerChaintoolMeta {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -491,16 +564,7 @@ public final class OrgHyperledgerChaintoolMeta {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new InterfaceDescriptor(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -551,11 +615,11 @@ public final class OrgHyperledgerChaintoolMeta {
    * Protobuf type {@code org.hyperledger.chaintool.meta.Interfaces}
    */
   public  static final class Interfaces extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:org.hyperledger.chaintool.meta.Interfaces)
       InterfacesOrBuilder {
     // Use Interfaces.newBuilder() to construct.
-    private Interfaces(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Interfaces(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Interfaces() {
@@ -569,7 +633,8 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     private Interfaces(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       int mutable_bitField0_ = 0;
       try {
@@ -591,17 +656,17 @@ public final class OrgHyperledgerChaintoolMeta {
                 descriptors_ = new java.util.ArrayList<org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor>();
                 mutable_bitField0_ |= 0x00000001;
               }
-              descriptors_.add(input.readMessage(org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor.parser(), extensionRegistry));
+              descriptors_.add(
+                  input.readMessage(org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor.parser(), extensionRegistry));
               break;
             }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
           descriptors_ = java.util.Collections.unmodifiableList(descriptors_);
@@ -614,7 +679,7 @@ public final class OrgHyperledgerChaintoolMeta {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Interfaces_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Interfaces_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -687,6 +752,38 @@ public final class OrgHyperledgerChaintoolMeta {
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces)) {
+        return super.equals(obj);
+      }
+      org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces other = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces) obj;
+
+      boolean result = true;
+      result = result && getDescriptorsList()
+          .equals(other.getDescriptorsList());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (getDescriptorsCount() > 0) {
+        hash = (37 * hash) + DESCRIPTORS_FIELD_NUMBER;
+        hash = (53 * hash) + getDescriptorsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -710,34 +807,40 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -754,7 +857,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -762,7 +865,7 @@ public final class OrgHyperledgerChaintoolMeta {
      * Protobuf type {@code org.hyperledger.chaintool.meta.Interfaces}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.hyperledger.chaintool.meta.Interfaces)
         org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfacesOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -770,7 +873,7 @@ public final class OrgHyperledgerChaintoolMeta {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Interfaces_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Interfaces_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -783,12 +886,13 @@ public final class OrgHyperledgerChaintoolMeta {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getDescriptorsFieldBuilder();
         }
       }
@@ -836,6 +940,32 @@ public final class OrgHyperledgerChaintoolMeta {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces) {
           return mergeFrom((org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces)other);
@@ -866,7 +996,7 @@ public final class OrgHyperledgerChaintoolMeta {
               descriptors_ = other.descriptors_;
               bitField0_ = (bitField0_ & ~0x00000001);
               descriptorsBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getDescriptorsFieldBuilder() : null;
             } else {
               descriptorsBuilder_.addAllMessages(other.descriptors_);
@@ -890,7 +1020,7 @@ public final class OrgHyperledgerChaintoolMeta {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Interfaces) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -909,7 +1039,7 @@ public final class OrgHyperledgerChaintoolMeta {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor.Builder, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptorOrBuilder> descriptorsBuilder_;
 
       /**
@@ -1125,11 +1255,11 @@ public final class OrgHyperledgerChaintoolMeta {
            getDescriptorsBuilderList() {
         return getDescriptorsFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor.Builder, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptorOrBuilder> 
           getDescriptorsFieldBuilder() {
         if (descriptorsBuilder_ == null) {
-          descriptorsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          descriptorsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptor.Builder, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.InterfaceDescriptorOrBuilder>(
                   descriptors_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
@@ -1169,16 +1299,7 @@ public final class OrgHyperledgerChaintoolMeta {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new Interfaces(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -1210,11 +1331,11 @@ public final class OrgHyperledgerChaintoolMeta {
    * Protobuf type {@code org.hyperledger.chaintool.meta.GetInterfacesParams}
    */
   public  static final class GetInterfacesParams extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:org.hyperledger.chaintool.meta.GetInterfacesParams)
       GetInterfacesParamsOrBuilder {
     // Use GetInterfacesParams.newBuilder() to construct.
-    private GetInterfacesParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private GetInterfacesParams(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private GetInterfacesParams() {
@@ -1228,7 +1349,8 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     private GetInterfacesParams(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       int mutable_bitField0_ = 0;
       try {
@@ -1253,11 +1375,10 @@ public final class OrgHyperledgerChaintoolMeta {
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         makeExtensionsImmutable();
       }
@@ -1267,7 +1388,7 @@ public final class OrgHyperledgerChaintoolMeta {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1314,6 +1435,37 @@ public final class OrgHyperledgerChaintoolMeta {
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams)) {
+        return super.equals(obj);
+      }
+      org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams other = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams) obj;
+
+      boolean result = true;
+      result = result && (getIncludeContent()
+          == other.getIncludeContent());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + INCLUDECONTENT_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getIncludeContent());
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1337,34 +1489,40 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -1381,7 +1539,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1389,7 +1547,7 @@ public final class OrgHyperledgerChaintoolMeta {
      * Protobuf type {@code org.hyperledger.chaintool.meta.GetInterfacesParams}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.hyperledger.chaintool.meta.GetInterfacesParams)
         org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1397,7 +1555,7 @@ public final class OrgHyperledgerChaintoolMeta {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1410,12 +1568,13 @@ public final class OrgHyperledgerChaintoolMeta {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -1449,6 +1608,32 @@ public final class OrgHyperledgerChaintoolMeta {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams) {
           return mergeFrom((org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams)other);
@@ -1480,7 +1665,7 @@ public final class OrgHyperledgerChaintoolMeta {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfacesParams) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1544,16 +1729,7 @@ public final class OrgHyperledgerChaintoolMeta {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new GetInterfacesParams(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -1590,11 +1766,11 @@ public final class OrgHyperledgerChaintoolMeta {
    * Protobuf type {@code org.hyperledger.chaintool.meta.GetInterfaceParams}
    */
   public  static final class GetInterfaceParams extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:org.hyperledger.chaintool.meta.GetInterfaceParams)
       GetInterfaceParamsOrBuilder {
     // Use GetInterfaceParams.newBuilder() to construct.
-    private GetInterfaceParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private GetInterfaceParams(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private GetInterfaceParams() {
@@ -1608,7 +1784,8 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     private GetInterfaceParams(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       int mutable_bitField0_ = 0;
       try {
@@ -1634,11 +1811,10 @@ public final class OrgHyperledgerChaintoolMeta {
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         makeExtensionsImmutable();
       }
@@ -1648,7 +1824,7 @@ public final class OrgHyperledgerChaintoolMeta {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1702,7 +1878,7 @@ public final class OrgHyperledgerChaintoolMeta {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getNameBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
     }
 
@@ -1712,13 +1888,43 @@ public final class OrgHyperledgerChaintoolMeta {
 
       size = 0;
       if (!getNameBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
       memoizedSize = size;
       return size;
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams)) {
+        return super.equals(obj);
+      }
+      org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams other = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams) obj;
+
+      boolean result = true;
+      result = result && getName()
+          .equals(other.getName());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getName().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1742,34 +1948,40 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -1786,7 +1998,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1794,7 +2006,7 @@ public final class OrgHyperledgerChaintoolMeta {
      * Protobuf type {@code org.hyperledger.chaintool.meta.GetInterfaceParams}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.hyperledger.chaintool.meta.GetInterfaceParams)
         org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1802,7 +2014,7 @@ public final class OrgHyperledgerChaintoolMeta {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1815,12 +2027,13 @@ public final class OrgHyperledgerChaintoolMeta {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -1854,6 +2067,32 @@ public final class OrgHyperledgerChaintoolMeta {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams) {
           return mergeFrom((org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams)other);
@@ -1886,7 +2125,7 @@ public final class OrgHyperledgerChaintoolMeta {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetInterfaceParams) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1993,16 +2232,7 @@ public final class OrgHyperledgerChaintoolMeta {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new GetInterfaceParams(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -2029,11 +2259,11 @@ public final class OrgHyperledgerChaintoolMeta {
    * Protobuf type {@code org.hyperledger.chaintool.meta.GetFactsParams}
    */
   public  static final class GetFactsParams extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:org.hyperledger.chaintool.meta.GetFactsParams)
       GetFactsParamsOrBuilder {
     // Use GetFactsParams.newBuilder() to construct.
-    private GetFactsParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private GetFactsParams(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private GetFactsParams() {
@@ -2046,7 +2276,8 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     private GetFactsParams(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       try {
         boolean done = false;
@@ -2065,11 +2296,10 @@ public final class OrgHyperledgerChaintoolMeta {
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         makeExtensionsImmutable();
       }
@@ -2079,7 +2309,7 @@ public final class OrgHyperledgerChaintoolMeta {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetFactsParams_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetFactsParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2110,6 +2340,32 @@ public final class OrgHyperledgerChaintoolMeta {
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams)) {
+        return super.equals(obj);
+      }
+      org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams other = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams) obj;
+
+      boolean result = true;
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2133,34 +2389,40 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -2177,7 +2439,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2185,7 +2447,7 @@ public final class OrgHyperledgerChaintoolMeta {
      * Protobuf type {@code org.hyperledger.chaintool.meta.GetFactsParams}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.hyperledger.chaintool.meta.GetFactsParams)
         org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2193,7 +2455,7 @@ public final class OrgHyperledgerChaintoolMeta {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetFactsParams_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_GetFactsParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2206,12 +2468,13 @@ public final class OrgHyperledgerChaintoolMeta {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -2242,6 +2505,32 @@ public final class OrgHyperledgerChaintoolMeta {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams) {
           return mergeFrom((org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams)other);
@@ -2270,7 +2559,7 @@ public final class OrgHyperledgerChaintoolMeta {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.GetFactsParams) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -2308,16 +2597,7 @@ public final class OrgHyperledgerChaintoolMeta {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new GetFactsParams(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -2368,11 +2648,11 @@ public final class OrgHyperledgerChaintoolMeta {
    * Protobuf type {@code org.hyperledger.chaintool.meta.Facts}
    */
   public  static final class Facts extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:org.hyperledger.chaintool.meta.Facts)
       FactsOrBuilder {
     // Use Facts.newBuilder() to construct.
-    private Facts(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Facts(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Facts() {
@@ -2386,7 +2666,8 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     private Facts(
         com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       int mutable_bitField0_ = 0;
       try {
@@ -2408,17 +2689,17 @@ public final class OrgHyperledgerChaintoolMeta {
                 facts_ = new java.util.ArrayList<org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact>();
                 mutable_bitField0_ |= 0x00000001;
               }
-              facts_.add(input.readMessage(org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact.parser(), extensionRegistry));
+              facts_.add(
+                  input.readMessage(org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact.parser(), extensionRegistry));
               break;
             }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw new RuntimeException(e.setUnfinishedMessage(this));
+        throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new RuntimeException(
-            new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this));
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
           facts_ = java.util.Collections.unmodifiableList(facts_);
@@ -2431,7 +2712,7 @@ public final class OrgHyperledgerChaintoolMeta {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2466,11 +2747,11 @@ public final class OrgHyperledgerChaintoolMeta {
      * Protobuf type {@code org.hyperledger.chaintool.meta.Facts.Fact}
      */
     public  static final class Fact extends
-        com.google.protobuf.GeneratedMessage implements
+        com.google.protobuf.GeneratedMessageV3 implements
         // @@protoc_insertion_point(message_implements:org.hyperledger.chaintool.meta.Facts.Fact)
         FactOrBuilder {
       // Use Fact.newBuilder() to construct.
-      private Fact(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      private Fact(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
       }
       private Fact() {
@@ -2485,7 +2766,8 @@ public final class OrgHyperledgerChaintoolMeta {
       }
       private Fact(
           com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
         this();
         int mutable_bitField0_ = 0;
         try {
@@ -2517,11 +2799,10 @@ public final class OrgHyperledgerChaintoolMeta {
             }
           }
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw new RuntimeException(e.setUnfinishedMessage(this));
+          throw e.setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
-          throw new RuntimeException(
-              new com.google.protobuf.InvalidProtocolBufferException(
-                  e.getMessage()).setUnfinishedMessage(this));
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
         } finally {
           makeExtensionsImmutable();
         }
@@ -2531,7 +2812,7 @@ public final class OrgHyperledgerChaintoolMeta {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_Fact_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_Fact_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2619,10 +2900,10 @@ public final class OrgHyperledgerChaintoolMeta {
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         if (!getNameBytes().isEmpty()) {
-          com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
         }
         if (!getValueBytes().isEmpty()) {
-          com.google.protobuf.GeneratedMessage.writeString(output, 2, value_);
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 2, value_);
         }
       }
 
@@ -2632,16 +2913,50 @@ public final class OrgHyperledgerChaintoolMeta {
 
         size = 0;
         if (!getNameBytes().isEmpty()) {
-          size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
         }
         if (!getValueBytes().isEmpty()) {
-          size += com.google.protobuf.GeneratedMessage.computeStringSize(2, value_);
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, value_);
         }
         memoizedSize = size;
         return size;
       }
 
       private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact)) {
+          return super.equals(obj);
+        }
+        org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact other = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact) obj;
+
+        boolean result = true;
+        result = result && getName()
+            .equals(other.getName());
+        result = result && getValue()
+            .equals(other.getValue());
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptorForType().hashCode();
+        hash = (37 * hash) + NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getName().hashCode();
+        hash = (37 * hash) + VALUE_FIELD_NUMBER;
+        hash = (53 * hash) + getValue().hashCode();
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
       public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2665,34 +2980,40 @@ public final class OrgHyperledgerChaintoolMeta {
       }
       public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact parseFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return PARSER.parseFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
       public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
       public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
       }
       public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
       public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
-        return PARSER.parseFrom(input);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
       }
       public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
       }
 
       public Builder newBuilderForType() { return newBuilder(); }
@@ -2709,7 +3030,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
       @java.lang.Override
       protected Builder newBuilderForType(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         Builder builder = new Builder(parent);
         return builder;
       }
@@ -2717,7 +3038,7 @@ public final class OrgHyperledgerChaintoolMeta {
        * Protobuf type {@code org.hyperledger.chaintool.meta.Facts.Fact}
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
           // @@protoc_insertion_point(builder_implements:org.hyperledger.chaintool.meta.Facts.Fact)
           org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.FactOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
@@ -2725,7 +3046,7 @@ public final class OrgHyperledgerChaintoolMeta {
           return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_Fact_descriptor;
         }
 
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
           return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_Fact_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
@@ -2738,12 +3059,13 @@ public final class OrgHyperledgerChaintoolMeta {
         }
 
         private Builder(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
           super(parent);
           maybeForceBuilderInitialization();
         }
         private void maybeForceBuilderInitialization() {
-          if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
           }
         }
         public Builder clear() {
@@ -2780,6 +3102,32 @@ public final class OrgHyperledgerChaintoolMeta {
           return result;
         }
 
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
         public Builder mergeFrom(com.google.protobuf.Message other) {
           if (other instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact) {
             return mergeFrom((org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact)other);
@@ -2816,7 +3164,7 @@ public final class OrgHyperledgerChaintoolMeta {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
             parsedMessage = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact) e.getUnfinishedMessage();
-            throw e;
+            throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
               mergeFrom(parsedMessage);
@@ -2992,16 +3340,7 @@ public final class OrgHyperledgerChaintoolMeta {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-          try {
             return new Fact(input, extensionRegistry);
-          } catch (RuntimeException e) {
-            if (e.getCause() instanceof
-                com.google.protobuf.InvalidProtocolBufferException) {
-              throw (com.google.protobuf.InvalidProtocolBufferException)
-                  e.getCause();
-            }
-            throw e;
-          }
         }
       };
 
@@ -3086,6 +3425,38 @@ public final class OrgHyperledgerChaintoolMeta {
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts)) {
+        return super.equals(obj);
+      }
+      org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts other = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts) obj;
+
+      boolean result = true;
+      result = result && getFactsList()
+          .equals(other.getFactsList());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (getFactsCount() > 0) {
+        hash = (37 * hash) + FACTS_FIELD_NUMBER;
+        hash = (53 * hash) + getFactsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -3109,34 +3480,40 @@ public final class OrgHyperledgerChaintoolMeta {
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public Builder newBuilderForType() { return newBuilder(); }
@@ -3153,7 +3530,7 @@ public final class OrgHyperledgerChaintoolMeta {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -3161,7 +3538,7 @@ public final class OrgHyperledgerChaintoolMeta {
      * Protobuf type {@code org.hyperledger.chaintool.meta.Facts}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.hyperledger.chaintool.meta.Facts)
         org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.FactsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -3169,7 +3546,7 @@ public final class OrgHyperledgerChaintoolMeta {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.internal_static_org_hyperledger_chaintool_meta_Facts_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -3182,12 +3559,13 @@ public final class OrgHyperledgerChaintoolMeta {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getFactsFieldBuilder();
         }
       }
@@ -3235,6 +3613,32 @@ public final class OrgHyperledgerChaintoolMeta {
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts) {
           return mergeFrom((org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts)other);
@@ -3265,7 +3669,7 @@ public final class OrgHyperledgerChaintoolMeta {
               facts_ = other.facts_;
               bitField0_ = (bitField0_ & ~0x00000001);
               factsBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getFactsFieldBuilder() : null;
             } else {
               factsBuilder_.addAllMessages(other.facts_);
@@ -3289,7 +3693,7 @@ public final class OrgHyperledgerChaintoolMeta {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -3308,7 +3712,7 @@ public final class OrgHyperledgerChaintoolMeta {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact.Builder, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.FactOrBuilder> factsBuilder_;
 
       /**
@@ -3524,11 +3928,11 @@ public final class OrgHyperledgerChaintoolMeta {
            getFactsBuilderList() {
         return getFactsFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact.Builder, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.FactOrBuilder> 
           getFactsFieldBuilder() {
         if (factsBuilder_ == null) {
-          factsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          factsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.Fact.Builder, org.hyperledger.chaintool.meta.OrgHyperledgerChaintoolMeta.Facts.FactOrBuilder>(
                   facts_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
@@ -3568,16 +3972,7 @@ public final class OrgHyperledgerChaintoolMeta {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        try {
           return new Facts(input, extensionRegistry);
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof
-              com.google.protobuf.InvalidProtocolBufferException) {
-            throw (com.google.protobuf.InvalidProtocolBufferException)
-                e.getCause();
-          }
-          throw e;
-        }
       }
     };
 
@@ -3596,47 +3991,47 @@ public final class OrgHyperledgerChaintoolMeta {
 
   }
 
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_hyperledger_chaintool_meta_Interfaces_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_hyperledger_chaintool_meta_Interfaces_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_hyperledger_chaintool_meta_GetFactsParams_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_hyperledger_chaintool_meta_GetFactsParams_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_hyperledger_chaintool_meta_Facts_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_hyperledger_chaintool_meta_Facts_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_hyperledger_chaintool_meta_Facts_Fact_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_hyperledger_chaintool_meta_Facts_Fact_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
   }
-  private static com.google.protobuf.Descriptors.FileDescriptor
+  private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {
@@ -3667,43 +4062,43 @@ public final class OrgHyperledgerChaintoolMeta {
     internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_hyperledger_chaintool_meta_InterfaceDescriptor_descriptor,
         new java.lang.String[] { "Name", "Data", });
     internal_static_org_hyperledger_chaintool_meta_Interfaces_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_org_hyperledger_chaintool_meta_Interfaces_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_hyperledger_chaintool_meta_Interfaces_descriptor,
         new java.lang.String[] { "Descriptors", });
     internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_hyperledger_chaintool_meta_GetInterfacesParams_descriptor,
         new java.lang.String[] { "IncludeContent", });
     internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_hyperledger_chaintool_meta_GetInterfaceParams_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_org_hyperledger_chaintool_meta_GetFactsParams_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_org_hyperledger_chaintool_meta_GetFactsParams_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_hyperledger_chaintool_meta_GetFactsParams_descriptor,
         new java.lang.String[] { });
     internal_static_org_hyperledger_chaintool_meta_Facts_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_org_hyperledger_chaintool_meta_Facts_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_hyperledger_chaintool_meta_Facts_descriptor,
         new java.lang.String[] { "Facts", });
     internal_static_org_hyperledger_chaintool_meta_Facts_Fact_descriptor =
       internal_static_org_hyperledger_chaintool_meta_Facts_descriptor.getNestedTypes().get(0);
     internal_static_org_hyperledger_chaintool_meta_Facts_Fact_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_hyperledger_chaintool_meta_Facts_Fact_descriptor,
         new java.lang.String[] { "Name", "Value", });
   }


### PR DESCRIPTION
We update chaintool to use the released protobuf v3.0.2 as well as java 1.8

Signed-off-by: Greg Haskins <gregory.haskins@gmail.com>