### PR TITLE
Golang generator matches shim interface for fabric v0.6.1

### DIFF
--- a/examples/invoker/src/chaincode/chaincode.go
+++ b/examples/invoker/src/chaincode/chaincode.go
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package chaincode
+package main
 
 import (
 	"fmt"
@@ -90,7 +90,7 @@ func (t *ChaincodeExample) CheckBalance(stub shim.ChaincodeStubInterface, param 
 
 func main() {
 	self := &ChaincodeExample{}
-	interfaces := ccs.Interfaces {
+	interfaces := ccs.Interfaces{
 		"org.hyperledger.chaincode.example02": self,
 		"appinit": self,
 	}

--- a/resources/generators/golang.stg
+++ b/resources/generators/golang.stg
@@ -424,8 +424,14 @@ implementclient(txn, intf, func) ::=
 func <func.name>(stub shim.ChaincodeStubInterface, chaincodeName string<if(func.param)>, params *<func.param><endif>) <\\>
 <if(func.rettype)>(*<func.rettype>, error)<else>error<endif> {
 
-     args := make([]string, 1)
+     <if(func.param)>
+     args := make([][]byte, 2)
+     <else>
+     args := make([][]byte, 1)
+     <endif>
      var err error
+
+     args[0] = []byte(<compositename(txn, intf, func)>)
 
      <if(func.param)>
      _pboutput, err := proto.Marshal(params)
@@ -433,10 +439,11 @@ func <func.name>(stub shim.ChaincodeStubInterface, chaincodeName string<if(func.
           return <if(func.rettype)>nil, <endif>err
      }
 
-     args[0] = base64.StdEncoding.EncodeToString(_pboutput)
+     args[1] = make([]byte, base64.StdEncoding.EncodedLen(len(_pboutput)))
+     base64.StdEncoding.Encode(args[1], _pboutput)
      <endif>
 
-     <if(func.rettype)>_result, err :=<else>_, err =<endif> stub.<if(txn)>Invoke<else>Query<endif>Chaincode(chaincodeName, <compositename(txn, intf, func)>, args)
+     <if(func.rettype)>_result, err :=<else>_, err =<endif> stub.<if(txn)>Invoke<else>Query<endif>Chaincode(chaincodeName, args)
 
      <if(func.rettype)>
      result := &<func.rettype>{}


### PR DESCRIPTION
Fixes #35 

The template file `resources/generators/golang.stg` has been modified so the calls to `stub.InvokeChaincode` and `stub.QueryChaincode` use the correct call signature.


The invoker example now compiles into an executable with `chaintool build`.

```
vagrant@hyperledger-devenv:v0.0.11-e6ff0ff:~/fabric-chaintool/examples/invoker$ ../../target/chaintool build
Build using configuration for  ./
[CCI] parse org.hyperledger.chaincode.example02
[CCI] parse appinit
[PB] protoc --go_out=/home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/org/hyperledger/chaincode/example02 --proto_path=/home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/org/hyperledger/chaincode/example02 /home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/org/hyperledger/chaincode/example02/interface.proto

[PB] protoc --go_out=/home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/appinit --proto_path=/home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/appinit /home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/appinit/interface.proto

[PB] protoc --go_out=/home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/org/hyperledger/chaintool/meta --proto_path=/home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/org/hyperledger/chaintool/meta /home/vagrant/fabric-chaintool/examples/invoker/build/src/hyperledger/cci/org/hyperledger/chaintool/meta/interface.proto

[GO] go get -d -v chaincode
        Using GOPATH /home/vagrant/fabric-chaintool/examples/invoker/build/deps:/home/vagrant/fabric-chaintool/examples/invoker/build:/home/vagrant/fabric-chaintool/examples/invoker:/opt/gopath

[GO] go build -o /home/vagrant/fabric-chaintool/examples/invoker/build/bin/org.hyperledger.chaincode.example.invoker-0.1-SNAPSHOT chaincode
        Using GOPATH /home/vagrant/fabric-chaintool/examples/invoker/build/deps:/home/vagrant/fabric-chaintool/examples/invoker/build:/home/vagrant/fabric-chaintool/examples/invoker:/opt/gopath

Compilation complete
```

**Testing**

I compiled the invoker proto files so that I could interact with the invoker cc using the example02 client (rest/cljs).

```
$ chaintool proto src/interfaces/appinit.cci
$ chaintool proto src/interfaces/org.hyperledger.chaincode.example02.cci
```

To use the example02 client for the invoker, link to it from the location of `appinit.proto` and `org.hyperledger.chaincode.example02.proto` produced from the above commands.

```
$ ln -s ../example02/client/rest/cljs/out out
```

Start the invoker in another terminal

```
CORE_CHAINCODE_ID_NAME=invoker CORE_PEER_ADDRESS=0.0.0.0:7051 ./build/bin/org.hyperledger.chaincode.example.invoker-0.1-SNAPSHOT
```

Now deploy and interact with the invoker cc and point it to a running example02 cc (here using the cc id name "example02")

```
$ nodejs ./out/example02.js --port 7050 -n invoker -c deploy -a '{"address":"example02"}'
$ nodejs ./out/example02.js --port 7050 -n invoker -c check-balance -a '{"id":"a"}'
$ nodejs ./out/example02.js --port 7050 -n invoker -c make-payment -a '{"partySrc":"a","partyDst":"b","amount":50}'
```