### PR TITLE
Add "chaintool env" command

### DIFF
--- a/src/chaintool/build/core.clj
+++ b/src/chaintool/build/core.clj
@@ -16,7 +16,15 @@
             [chaintool.platforms.api :as platforms.api])
   (:refer-clojure :exclude [compile]))
 
-(defn compile [{:keys [config] :as params}]
+
+(defn- run [fcn {:keys [config] :as params}]
   (when-let [platform (platforms.core/find config)]
-    ;; generate platform output (shim, protobufs, etc)
-    (platforms.api/build platform params)))
+    (fcn platform params)))
+
+;; generate platform output (shim, protobufs, etc)
+(defn compile [params]
+  (run platforms.api/build params))
+
+;; display environment variables used for build
+(defn env [params]
+  (run platforms.api/env params))

--- a/src/chaintool/core.clj
+++ b/src/chaintool/core.clj
@@ -21,6 +21,7 @@
             [chaintool.subcommands.package :as packagecmd]
             [chaintool.subcommands.proto :as protocmd]
             [chaintool.subcommands.unpack :as unpackcmd]
+            [chaintool.subcommands.env :as envcmd]
             [chaintool.util :as util]
             [clojure.string :as string]
             [clojure.tools.cli :refer [parse-opts]]
@@ -77,6 +78,10 @@
     :arguments "path/to/file.car"
     :validate (fn [options arguments] (= (count arguments) 1))
     :options common-options}
+
+   {:name "env" :desc "Display variables used in the build environment"
+    :handler envcmd/run
+    :options common-path-options}
 
    {:name "proto" :desc "Compiles a CCI file to a .proto"
     :handler protocmd/run

--- a/src/chaintool/platforms/golang/system.clj
+++ b/src/chaintool/platforms/golang/system.clj
@@ -42,6 +42,11 @@
   platforms.api/Platform
 
   ;;-----------------------------------------------------------------
+  ;; env - Emits the GOPATH used for building system chaincode
+  ;;-----------------------------------------------------------------
+  (env [_ _])
+
+  ;;-----------------------------------------------------------------
   ;; build - generates all golang platform artifacts within the
   ;; default location in the build area
   ;;-----------------------------------------------------------------

--- a/src/chaintool/platforms/golang/userspace.clj
+++ b/src/chaintool/platforms/golang/userspace.clj
@@ -31,6 +31,12 @@
   platforms.api/Platform
 
   ;;-----------------------------------------------------------------
+  ;; env - Emits the GOPATH used for building golang chaincode
+  ;;-----------------------------------------------------------------
+  (env [_ {:keys [path]}]
+    (println (str "GOPATH=" (buildgopath path))))
+
+  ;;-----------------------------------------------------------------
   ;; build - generates all golang platform artifacts within the
   ;; default location in the build area
   ;;-----------------------------------------------------------------

--- a/src/chaintool/subcommands/env.clj
+++ b/src/chaintool/subcommands/env.clj
@@ -1,5 +1,3 @@
-;; Copyright London Stock Exchange Group 2016 All Rights Reserved.
-;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
 ;; You may obtain a copy of the License at
@@ -12,14 +10,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(ns chaintool.platforms.api)
+(ns chaintool.subcommands.env
+  (:require [chaintool.config.util :as config.util]
+            [chaintool.build.core :as build.core]))
 
-(defprotocol Platform
-  ;; Displays environment variables relevant to the build environment
-  (env [this params])
-  ;; Compiles the platform
-  (build [this params])
-  ;; Cleans any previous builds of the platform
-  (clean [this params])
-  ;; Packages the chaincode project according to the platform
-  (package [this params]))
+(defn run [options args]
+  (let [[path config] (config.util/load-from-options options)]
+    (build.core/env {:path path :config config})))


### PR DESCRIPTION
This would make it easy to instrument certain IDEs such as:

> env $(chaintool env) vim src/chaincode/chaincode.go

Implements enhancement #37

Signed-off-by: Greg Haskins <gregory.haskins@gmail.com>