### PR TITLE
Fix generation of client-stub.go for consumed chaincode -- fix "invoker"

### DIFF
--- a/examples/invoker/src/chaincode/chaincode.go
+++ b/examples/invoker/src/chaincode/chaincode.go
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package chaincode
+package main
 
 import (
 	"fmt"
@@ -90,7 +90,7 @@ func (t *ChaincodeExample) CheckBalance(stub shim.ChaincodeStubInterface, param 
 
 func main() {
 	self := &ChaincodeExample{}
-	interfaces := ccs.Interfaces {
+	interfaces := ccs.Interfaces{
 		"org.hyperledger.chaincode.example02": self,
 		"appinit": self,
 	}

--- a/resources/generators/golang.stg
+++ b/resources/generators/golang.stg
@@ -424,8 +424,14 @@ implementclient(txn, intf, func) ::=
 func <func.name>(stub shim.ChaincodeStubInterface, chaincodeName string<if(func.param)>, params *<func.param><endif>) <\\>
 <if(func.rettype)>(*<func.rettype>, error)<else>error<endif> {
 
-     args := make([]string, 1)
+     <if(func.param)>
+     args := make([][]byte, 2)
+     <else>
+     args := make([][]byte, 1)
+     <endif>
      var err error
+
+     args[0] = []byte(<compositename(txn, intf, func)>)
 
      <if(func.param)>
      _pboutput, err := proto.Marshal(params)
@@ -433,10 +439,11 @@ func <func.name>(stub shim.ChaincodeStubInterface, chaincodeName string<if(func.
           return <if(func.rettype)>nil, <endif>err
      }
 
-     args[0] = base64.StdEncoding.EncodeToString(_pboutput)
+     args[1] = make([]byte, base64.StdEncoding.EncodedLen(len(_pboutput)))
+     base64.StdEncoding.Encode(args[1], _pboutput)
      <endif>
 
-     <if(func.rettype)>_result, err :=<else>_, err =<endif> stub.<if(txn)>Invoke<else>Query<endif>Chaincode(chaincodeName, <compositename(txn, intf, func)>, args)
+     <if(func.rettype)>_result, err :=<else>_, err =<endif> stub.<if(txn)>Invoke<else>Query<endif>Chaincode(chaincodeName, args)
 
      <if(func.rettype)>
      result := &<func.rettype>{}


### PR DESCRIPTION
A second attempt after I messed up #36. Refer to it for additional details.

The v0.9.x code generating template was producing calls in
client-stub.go using an incorrect signature for the following methods on
ChaincodeStubInterface (as of fabric v0.6.1-preview):

    InvokeChaincode(chaincodeName string, args [][]byte) ([]byte, error)
    QueryChaincode(chaincodeName string, args [][]byte) ([]byte, error)

These incorrect signatures were apparently part of an older API that
looked like the following:

    Invoke(chaincodeName string, function string, args []string) ([]byte, error)
    Query(chaincodeName string, function string, args []string) ([]byte, error)

As a secondary fix, the invoker example's Go source had the package name
"chaincode" instead of "main".  This made the `chaintool build` command
produce archive files instead of executable binaries as desired.  This
fix is included in this patch because it is needed to validate the
change made to the Go template.

Signed-off-by: Bryan Matsuo <bryan.matsuo@gmail.com>